### PR TITLE
feat: native PWA polish, media detail page, dashboard + sync fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ dist
 dist-ssr
 output
 build
+.notes
 *.local
 
 # Editor directories and files

--- a/docs/phases/phase-16-youtube-token-expiry.sql
+++ b/docs/phases/phase-16-youtube-token-expiry.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- Phase 16 — YouTube Connection Token Expiry Patch
+-- Run this on existing databases that predate the YouTube
+-- token expiry column or contain null expiry timestamps.
+-- The app uses this column to show the current access-token
+-- refresh window and to know when refresh/disconnect logic
+-- should run.
+-- ============================================================
+
+ALTER TABLE public.youtube_connections
+  ADD COLUMN IF NOT EXISTS token_expires_at timestamptz;
+
+UPDATE public.youtube_connections
+SET token_expires_at = now()
+WHERE token_expires_at IS NULL;
+
+ALTER TABLE public.youtube_connections
+  ALTER COLUMN token_expires_at SET NOT NULL;

--- a/index.html
+++ b/index.html
@@ -4,12 +4,14 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
-  <meta name="theme-color" content="#E33483" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
+  <meta name="theme-color" content="#ffffff" media="(prefers-color-scheme: light)" />
+  <meta name="theme-color" content="#171717" media="(prefers-color-scheme: dark)" />
   <meta name="description" content="Production operations console for broadcast teams — streams, meetings, cues, requests." />
   <!-- iOS PWA meta -->
   <meta name="apple-mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+  <meta name="mobile-web-app-capable" content="yes" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
   <meta name="apple-mobile-web-app-title" content="MOC Console" />
   <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
   <script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { Spinner } from '@/components/feedback/spinner'
 import { useAuth } from './lib/auth-context'
 import { AppShell } from './features/app-shell'
 import { BroadcastMediaScreen } from '@/screens/broadcast/media/page'
+import { MediaDetailScreen } from '@/screens/broadcast/media/detail/page'
 import { BroadcastOverviewScreen } from '@/screens/broadcast/page'
 import { PlaylistScreen } from '@/screens/broadcast/playlist/page'
 import { PlaylistDetailScreen } from '@/screens/broadcast/detail/page'
@@ -134,6 +135,7 @@ const router = createBrowserRouter([
                 children: [
                     { path: routes.broadcastOverview, element: <BroadcastOverviewScreen /> },
                     { path: routes.broadcastMedia, element: <BroadcastMediaScreen /> },
+                    { path: routes.broadcastMediaDetail, element: <MediaDetailScreen /> },
                     { path: routes.broadcastPlaylists, element: <PlaylistScreen /> },
                     { path: routes.broadcastPlaylistDetail, element: <PlaylistDetailScreen /> },
                     { path: routes.broadcastStreams, element: <StreamsScreen /> },

--- a/src/components/navigation/sidebar.tsx
+++ b/src/components/navigation/sidebar.tsx
@@ -136,8 +136,8 @@ function SidebarPanel({ children, className }: HTMLAttributes<HTMLDivElement>) {
 function SidebarHeader({ children, className }: HTMLAttributes<HTMLDivElement>) {
     const { state } = useSidebar()
     return (
-        <header className={cn("h-header px-2 py-2 border-b border-secondary inline-flex justify-start items-center overflow-hidden", className)}>
-            <div className={cn("flex-1 flex justify-start items-center gap-2.5", state.isCollapsed && "justify-center")}>
+        <header className={cn("px-2 pt-[calc(env(safe-area-inset-top)+0.5rem)] pb-2 border-b border-secondary inline-flex justify-start items-center overflow-hidden", className)}>
+            <div className={cn("flex-1 flex justify-start items-center gap-2.5 h-8", state.isCollapsed && "justify-center")}>
                 {children}
             </div>
         </header>
@@ -156,7 +156,7 @@ function SidebarContent({ children, className }: HTMLAttributes<HTMLDivElement>)
 function SidebarFooter({ children, className }: HTMLAttributes<HTMLDivElement>) {
     const { state } = useSidebar()
     return (
-        <div className={cn("px-2 py-3 border-t border-secondary inline-flex justify-start items-center overflow-hidden", className)}>
+        <div className={cn("px-2 pt-3 pb-[calc(env(safe-area-inset-bottom)+0.75rem)] border-t border-secondary inline-flex justify-start items-center overflow-hidden", className)}>
             <div className={cn("flex-1 rounded-lg flex justify-start items-center gap-2", state.isCollapsed && "justify-center")}>
                 {children}
             </div>

--- a/src/data/fetch-streams.ts
+++ b/src/data/fetch-streams.ts
@@ -41,6 +41,7 @@ type ConnectionRow = {
   presets: StreamPreset | null
   connected_by: string
   created_at: string
+  token_expires_at: string
 }
 
 function mapStreamRow(row: StreamRow): Stream {
@@ -84,6 +85,7 @@ function mapConnectionRow(row: ConnectionRow): YouTubeConnection {
     presets: row.presets ?? null,
     connectedBy: row.connected_by,
     createdAt: row.created_at,
+    tokenExpiresAt: row.token_expires_at,
   }
 }
 
@@ -124,7 +126,7 @@ export async function fetchYouTubeConnection(): Promise<YouTubeConnection | null
   const workspaceId = await getCurrentWorkspaceId()
   const { data, error } = await supabase
     .from("youtube_connections")
-    .select("id, workspace_id, channel_id, channel_title, presets, connected_by, created_at")
+    .select("id, workspace_id, channel_id, channel_title, presets, connected_by, created_at, token_expires_at")
     .eq("workspace_id", workspaceId)
     .maybeSingle()
 

--- a/src/data/mutate-streams.ts
+++ b/src/data/mutate-streams.ts
@@ -329,24 +329,27 @@ export async function syncStreamsFromYouTube(): Promise<Stream[]> {
     throw new Error("Not authenticated")
   }
 
-  // Fetch from YouTube, paginating through all pages
+  // Fetch only upcoming (scheduled) and active (live) broadcasts. Completed
+  // broadcasts stay in our DB and are not re-fetched.
   const broadcasts: any[] = []
-  let pageToken: string | undefined = undefined
-  do {
-    const pageParam = pageToken ? `&pageToken=${pageToken}` : ""
-    const response = await youtubeApiFetch(
-      `/liveBroadcasts?part=snippet,status,contentDetails&broadcastType=all&mine=true&maxResults=50${pageParam}`,
-    )
+  for (const broadcastStatus of ["upcoming", "active"] as const) {
+    let pageToken: string | undefined = undefined
+    do {
+      const pageParam = pageToken ? `&pageToken=${pageToken}` : ""
+      const response = await youtubeApiFetch(
+        `/liveBroadcasts?part=snippet,status,contentDetails&broadcastStatus=${broadcastStatus}&broadcastType=all&maxResults=50${pageParam}`,
+      )
 
-    if (!response.ok) {
-      const err = await response.text()
-      throw new Error(`Failed to fetch broadcasts: ${err}`)
-    }
+      if (!response.ok) {
+        const err = await response.text()
+        throw new Error(`Failed to fetch broadcasts: ${err}`)
+      }
 
-    const data = await response.json()
-    broadcasts.push(...(data.items ?? []))
-    pageToken = data.nextPageToken
-  } while (pageToken)
+      const data = await response.json()
+      broadcasts.push(...(data.items ?? []))
+      pageToken = data.nextPageToken
+    } while (pageToken)
+  }
 
   // Map YouTube lifecycle status to our stream_status enum
   function mapLifecycleStatus(status: string): Stream["streamStatus"] {
@@ -395,11 +398,14 @@ export async function syncStreamsFromYouTube(): Promise<Stream[]> {
       .upsert(payload, { onConflict: "workspace_id,youtube_broadcast_id" })
   }
 
+  // Remove local non-complete streams that are no longer present remotely
+  // (cancelled before going live). Completed streams are preserved.
   const remoteIds = broadcasts.map((b) => b.id).filter(Boolean)
   let deleteQuery = supabase
     .from("streams")
     .delete()
     .eq("workspace_id", workspaceId)
+    .neq("stream_status", "complete")
   if (remoteIds.length > 0) {
     const quoted = remoteIds.map((id) => `"${id}"`).join(",")
     deleteQuery = deleteQuery.not("youtube_broadcast_id", "in", `(${quoted})`)

--- a/src/features/app-shell.tsx
+++ b/src/features/app-shell.tsx
@@ -158,7 +158,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                     <Breadcrumb.Root />
                 </TopBar>
 
-                <main className="area-content min-h-0 overflow-y-auto bg-[var(--background-color-primary)]">
+                <main className="area-content min-h-0 overflow-y-auto bg-[var(--background-color-primary)] pb-[env(safe-area-inset-bottom)]">
                     {children}
                 </main>
             </div>

--- a/src/features/broadcast/media-detail-drawer.tsx
+++ b/src/features/broadcast/media-detail-drawer.tsx
@@ -1,10 +1,13 @@
 import { useCallback, useState } from "react"
+import { useNavigate } from "react-router-dom"
 import { Drawer } from "@/components/overlays/drawer"
 import { Button } from "@/components/controls/button"
 import { Badge } from "@/components/display/badge"
 import { Label, Paragraph, Title } from "@/components/display/text"
 import { Divider } from "@/components/display/divider"
 import { MetaRow } from "@/components/display/meta-row"
+import { useAuth } from "@/lib/auth-context"
+import { routes } from "@/screens/console-routes"
 import { mediaTypeColor, mediaTypeLabel } from "@/types/broadcast/constants"
 import type { MediaItem } from "@/types/broadcast/media-item"
 import { formatUtcIsoInBrowserTimeZone } from "@/utils/browser-date-time"
@@ -15,7 +18,9 @@ import {
   Copy,
   ExternalLink,
   FileType,
+  Maximize2,
   Play,
+  Trash2,
   X,
 } from "lucide-react"
 
@@ -23,6 +28,7 @@ type MediaDetailDrawerProps = {
   item: MediaItem | null
   open: boolean
   onOpenChange: (open: boolean) => void
+  onDelete?: (item: MediaItem) => void
 }
 
 function formatDuration(seconds: number): string {
@@ -31,14 +37,24 @@ function formatDuration(seconds: number): string {
   return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`
 }
 
-export function MediaDetailDrawer({ item, open, onOpenChange }: MediaDetailDrawerProps) {
+export function MediaDetailDrawer({ item, open, onOpenChange, onDelete }: MediaDetailDrawerProps) {
+  const { role } = useAuth()
+  const navigate = useNavigate()
   const [copied, setCopied] = useState(false)
+
+  const canDelete = role?.can_delete === true
 
   const handleCopy = useCallback((text: string) => {
     navigator.clipboard.writeText(text)
     setCopied(true)
     setTimeout(() => setCopied(false), 2000)
   }, [])
+
+  const handleOpenFullPage = useCallback(() => {
+    if (!item) return
+    onOpenChange(false)
+    navigate(`/${routes.broadcastMediaDetail.replace(":id", item.id)}`)
+  }, [item, navigate, onOpenChange])
 
   if (!item) return null
 
@@ -49,7 +65,15 @@ export function MediaDetailDrawer({ item, open, onOpenChange }: MediaDetailDrawe
         <Drawer.Panel className="!max-w-lg">
           <Drawer.Header className="flex items-center gap-1">
             <Button.Icon variant="ghost" icon={<X />} onClick={() => onOpenChange(false)} />
+            <Button.Icon variant="ghost" icon={<Maximize2 />} onClick={handleOpenFullPage} />
             <div className="flex-1" />
+            {canDelete && (
+              <Button.Icon
+                variant="ghost"
+                icon={<Trash2 />}
+                onClick={() => onDelete?.(item)}
+              />
+            )}
           </Drawer.Header>
 
           <Drawer.Content className="py-4">

--- a/src/features/topbar.tsx
+++ b/src/features/topbar.tsx
@@ -49,17 +49,21 @@ export function TopBar({ children }: HTMLAttributes<HTMLDivElement>) {
         : (state.isCollapsed ? 'Expand sidebar' : 'Collapse sidebar')
 
     return (
-        <header className="area-topbar h-header border-b border-secondary flex items-center gap-2 px-4">
-            <button
-                type="button"
-                onClick={handleClick}
-                className="size-11 flex items-center justify-center rounded-md hover:bg-[var(--background-color-secondary_hover)] active:bg-[var(--background-color-secondary_hover)] text-[var(--text-color-secondary)] cursor-pointer"
-                aria-label={label}
-            >
-                <Icon className="size-5" />
-            </button>
-            {children}
-            <div ref={slotRef} className="ml-auto flex items-center gap-2" />
+        <header
+            className="area-topbar bg-primary border-b border-secondary flex items-center gap-2 px-4 pt-[env(safe-area-inset-top)]"
+        >
+            <div className="flex items-center gap-2 w-full h-header">
+                <button
+                    type="button"
+                    onClick={handleClick}
+                    className="size-11 flex items-center justify-center rounded-md hover:bg-[var(--background-color-secondary_hover)] active:bg-[var(--background-color-secondary_hover)] text-[var(--text-color-secondary)] cursor-pointer"
+                    aria-label={label}
+                >
+                    <Icon className="size-5" />
+                </button>
+                {children}
+                <div ref={slotRef} className="ml-auto flex items-center gap-2" />
+            </div>
         </header>
     )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -665,7 +665,7 @@
   display: grid;
   grid-template-areas: "topbar" "content";
   grid-template-columns: 1fr;
-  grid-template-rows: var(--spacing-header) 1fr;
+  grid-template-rows: auto 1fr;
   height: 100dvh;
 }
 
@@ -710,6 +710,22 @@ body,
   line-height: 1.4;
   -webkit-font-smoothing: antialiased;
   isolation: isolate;
+}
+
+/* Native-feel adjustments for installed PWA / mobile.
+   Removes the default tap-highlight overlay and the rubber-band overscroll
+   that breaks the illusion of a native app. */
+html,
+body {
+  -webkit-tap-highlight-color: transparent;
+  overscroll-behavior-y: none;
+}
+
+body {
+  /* iOS doesn't apply text-size-adjust by default in standalone PWAs;
+     pin it so rotation doesn't change typography. */
+  -webkit-text-size-adjust: 100%;
+  text-size-adjust: 100%;
 }
 
 #overlay-root {

--- a/src/screens/broadcast/media/detail/page.tsx
+++ b/src/screens/broadcast/media/detail/page.tsx
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from "react"
+import { useNavigate, useParams } from "react-router-dom"
+import { Header } from "@/components/display/header"
+import { Badge } from "@/components/display/badge"
+import { Button } from "@/components/controls/button"
+import { Divider } from "@/components/display/divider"
+import { Label, Paragraph, Title } from "@/components/display/text"
+import { MetaRow } from "@/components/display/meta-row"
+import { Spinner } from "@/components/feedback/spinner"
+import { EmptyState } from "@/components/feedback/empty-state"
+import { useFeedback } from "@/components/feedback/feedback-provider"
+import { useBreadcrumbOverride } from "@/components/navigation/breadcrumb"
+import { TopBarActions } from "@/features/topbar"
+import { useAuth } from "@/lib/auth-context"
+import { useBroadcast } from "@/features/broadcast/broadcast-provider"
+import { deleteMediaItem } from "@/data/mutate-broadcast"
+import { fetchMediaById } from "@/data/fetch-broadcast"
+import { mediaTypeColor, mediaTypeLabel } from "@/types/broadcast/constants"
+import type { MediaItem } from "@/types/broadcast/media-item"
+import { formatUtcIsoInBrowserTimeZone } from "@/utils/browser-date-time"
+import { getErrorMessage } from "@/utils/get-error-message"
+import { Modal } from "@/components/overlays/modal"
+import {
+  Calendar,
+  Check,
+  Clock,
+  Copy,
+  ExternalLink,
+  FileType,
+  Film,
+  Play,
+  Trash2,
+  TriangleAlert,
+} from "lucide-react"
+
+function formatDuration(seconds: number): string {
+  const m = Math.floor(seconds / 60)
+  const s = seconds % 60
+  return m > 0 ? `${m}:${String(s).padStart(2, "0")}` : `${s}s`
+}
+
+export function MediaDetailScreen() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+  const { toast } = useFeedback()
+  const { role } = useAuth()
+  const {
+    state: { media },
+    actions: { loadMedia, removeMediaItem },
+  } = useBroadcast()
+
+  const [item, setItem] = useState<MediaItem | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [deleteOpen, setDeleteOpen] = useState(false)
+  const [isDeleting, setIsDeleting] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  useEffect(() => { loadMedia() }, [loadMedia])
+
+  useEffect(() => {
+    if (!id) return
+    const fromContext = media.find((m) => m.id === id)
+    if (fromContext) {
+      setItem(fromContext)
+      setIsLoading(false)
+      return
+    }
+    let cancelled = false
+    fetchMediaById(id).then((data) => {
+      if (!cancelled) {
+        setItem(data ?? null)
+        setIsLoading(false)
+      }
+    })
+    return () => { cancelled = true }
+  }, [id, media])
+
+  useBreadcrumbOverride(id ?? "", item?.name)
+
+  const handleCopy = useCallback((text: string) => {
+    navigator.clipboard.writeText(text)
+    setCopied(true)
+    setTimeout(() => setCopied(false), 2000)
+  }, [])
+
+  const handleDelete = useCallback(async () => {
+    if (!item) return
+    setIsDeleting(true)
+    try {
+      await deleteMediaItem(item.id)
+      removeMediaItem(item.id)
+      toast({ title: "Media deleted", variant: "success" })
+      navigate("/broadcast/media")
+    } catch (error) {
+      toast({ title: "Failed to delete media", description: getErrorMessage(error, "The media item could not be deleted."), variant: "error" })
+    } finally {
+      setIsDeleting(false)
+      setDeleteOpen(false)
+    }
+  }, [item, removeMediaItem, toast, navigate])
+
+  if (isLoading) {
+    return (
+      <section className="flex justify-center py-16 mx-auto max-w-content-sm">
+        <Spinner size="lg" />
+      </section>
+    )
+  }
+
+  if (!item) {
+    return (
+      <section className="mx-auto max-w-content-sm">
+        <EmptyState icon={<Film />} title="Media not found" description="The media item you're looking for doesn't exist." />
+      </section>
+    )
+  }
+
+  const canDelete = role?.can_delete === true
+
+  return (
+    <section className="mx-auto max-w-content-sm">
+      <TopBarActions>
+        {canDelete && (
+          <Button.Icon variant="danger-secondary" icon={<Trash2 />} onClick={() => setDeleteOpen(true)} />
+        )}
+      </TopBarActions>
+
+      {/* Preview */}
+      <div className="px-4 pt-8">
+        <div className="w-full rounded-lg bg-secondary_alt border border-tertiary flex items-center justify-center overflow-hidden aspect-video">
+          {item.type === "image" && (
+            <img src={item.url} alt={item.name} className="size-full object-contain" />
+          )}
+          {item.type === "video" && (
+            <video src={item.url} poster={item.thumbnail ?? undefined} controls playsInline preload="metadata" className="size-full" />
+          )}
+          {item.type === "audio" && (
+            <div className="size-full flex flex-col items-center justify-center gap-4 p-6">
+              <div className="size-20 rounded-full bg-primary border border-tertiary flex items-center justify-center">
+                <Play className="size-8 text-tertiary" />
+              </div>
+              <audio src={item.url} controls preload="metadata" className="w-full max-w-xs" />
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Header */}
+      <Header.Root className="px-4 pt-8">
+        <Header.Lead className="gap-2">
+          <Title.h5>{item.name}</Title.h5>
+        </Header.Lead>
+      </Header.Root>
+
+      {/* Properties */}
+      <div className="p-4">
+        <div className="space-y-3">
+          <MetaRow icon={<FileType />} label="Type">
+            <Badge label={mediaTypeLabel[item.type]} color={mediaTypeColor[item.type]} />
+          </MetaRow>
+
+          {item.duration != null && (
+            <MetaRow icon={<Clock />} label="Duration">
+              <Paragraph.sm>{formatDuration(item.duration)}</Paragraph.sm>
+            </MetaRow>
+          )}
+
+          <MetaRow icon={<Calendar />} label="Created">
+            <Paragraph.sm>{formatUtcIsoInBrowserTimeZone(item.createdAt)}</Paragraph.sm>
+          </MetaRow>
+        </div>
+      </div>
+
+      {/* Source */}
+      <Divider className="px-4 my-2" />
+      <div className="p-4">
+        <Label.md className="block pb-3">Source URL</Label.md>
+        <div className="flex items-center gap-2">
+          <Paragraph.sm className="text-tertiary truncate flex-1">{item.url}</Paragraph.sm>
+          <Button.Icon
+            variant="ghost"
+            icon={copied ? <Check className="text-utility-green-700" /> : <Copy />}
+            onClick={() => handleCopy(item.url)}
+          />
+          <a href={item.url} target="_blank" rel="noopener noreferrer">
+            <Button.Icon variant="ghost" icon={<ExternalLink />} />
+          </a>
+        </div>
+      </div>
+
+      <Modal.Root open={deleteOpen} onOpenChange={(o) => { if (!o) setDeleteOpen(false) }}>
+        <Modal.Portal>
+          <Modal.Backdrop />
+          <Modal.Positioner>
+            <Modal.Panel>
+              <Modal.Header>
+                <Label.md>Delete Media</Label.md>
+              </Modal.Header>
+              <Modal.Content className="p-4 flex-row gap-4">
+                <TriangleAlert className="size-8 shrink-0 text-utility-red-600" />
+                <Paragraph.sm className="text-secondary">
+                  Are you sure you want to delete this media item? Playlist cues that reference it may be affected. This action cannot be undone.
+                </Paragraph.sm>
+              </Modal.Content>
+              <Modal.Footer className="justify-end">
+                <Button variant="secondary" onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                <Button variant="danger" onClick={handleDelete} disabled={isDeleting}>
+                  {isDeleting ? "Deleting..." : "Delete Media"}
+                </Button>
+              </Modal.Footer>
+            </Modal.Panel>
+          </Modal.Positioner>
+        </Modal.Portal>
+      </Modal.Root>
+    </section>
+  )
+}

--- a/src/screens/broadcast/media/page.tsx
+++ b/src/screens/broadcast/media/page.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react"
+import { useCallback, useEffect, useState } from "react"
 import { useFeedback } from "@/components/feedback/feedback-provider"
 import { Card } from "@/components/display/card"
 import { Header } from "@/components/display/header"
@@ -6,6 +6,7 @@ import { Input } from "@/components/form/input"
 import { Button } from "@/components/controls/button"
 import { Spinner } from "@/components/feedback/spinner"
 import { Label, Paragraph, Title } from "@/components/display/text"
+import { Modal } from "@/components/overlays/modal"
 import { useBroadcast } from "@/features/broadcast/broadcast-provider"
 import { useMediaFilters } from "@/features/broadcast/use-media-filters"
 import { MediaListItem } from "@/features/broadcast/media-list-item"
@@ -13,16 +14,16 @@ import { MediaDetailDrawer } from "@/features/broadcast/media-detail-drawer"
 import { UploadMediaModal } from "@/features/broadcast/upload-media-modal"
 import type { MediaItem } from "@/types/broadcast"
 import type { MediaType } from "@/types/broadcast"
-import { createMediaItem } from "@/data/mutate-broadcast"
+import { createMediaItem, deleteMediaItem } from "@/data/mutate-broadcast"
 import { getErrorMessage } from "@/utils/get-error-message"
-import { Film, Plus, Search } from "lucide-react"
+import { Film, Plus, Search, TriangleAlert } from "lucide-react"
 import { SegmentedControl } from "@/components/controls/segmented-control"
 
 
 export function BroadcastMediaScreen() {
   const {
     state: { media, isLoadingMedia },
-    actions: { loadMedia, syncMediaItem },
+    actions: { loadMedia, syncMediaItem, removeMediaItem },
   } = useBroadcast()
   const { toast } = useFeedback()
 
@@ -35,6 +36,8 @@ export function BroadcastMediaScreen() {
 
   const [selectedItem, setSelectedItem] = useState<MediaItem | null>(null)
   const [uploadOpen, setUploadOpen] = useState(false)
+  const [pendingDelete, setPendingDelete] = useState<MediaItem | null>(null)
+  const [isDeleting, setIsDeleting] = useState(false)
 
   function handleTabChange(tab: string) {
     setType(tab === "all" ? null : (tab as MediaType))
@@ -49,6 +52,22 @@ export function BroadcastMediaScreen() {
       throw error
     }
   }
+
+  const handleDelete = useCallback(async () => {
+    if (!pendingDelete) return
+    setIsDeleting(true)
+    try {
+      await deleteMediaItem(pendingDelete.id)
+      removeMediaItem(pendingDelete.id)
+      toast({ title: "Media deleted", variant: "success" })
+      setSelectedItem(null)
+      setPendingDelete(null)
+    } catch (error) {
+      toast({ title: "Failed to delete media", description: getErrorMessage(error, "The media item could not be deleted."), variant: "error" })
+    } finally {
+      setIsDeleting(false)
+    }
+  }, [pendingDelete, removeMediaItem, toast])
 
   return (
     <section className="h-full flex flex-col">
@@ -109,6 +128,7 @@ export function BroadcastMediaScreen() {
         item={selectedItem}
         open={selectedItem !== null}
         onOpenChange={(open) => { if (!open) setSelectedItem(null) }}
+        onDelete={(item) => setPendingDelete(item)}
       />
 
       <UploadMediaModal
@@ -116,6 +136,31 @@ export function BroadcastMediaScreen() {
         onOpenChange={setUploadOpen}
         onSubmit={handleUploadSubmit}
       />
+
+      <Modal.Root open={pendingDelete !== null} onOpenChange={(o) => { if (!o) setPendingDelete(null) }}>
+        <Modal.Portal>
+          <Modal.Backdrop />
+          <Modal.Positioner>
+            <Modal.Panel>
+              <Modal.Header>
+                <Label.md>Delete Media</Label.md>
+              </Modal.Header>
+              <Modal.Content className="p-4 flex-row gap-4">
+                <TriangleAlert className="size-8 shrink-0 text-utility-red-600" />
+                <Paragraph.sm className="text-secondary">
+                  Are you sure you want to delete this media item? Playlist cues that reference it may be affected. This action cannot be undone.
+                </Paragraph.sm>
+              </Modal.Content>
+              <Modal.Footer className="justify-end">
+                <Button variant="secondary" onClick={() => setPendingDelete(null)}>Cancel</Button>
+                <Button variant="danger" onClick={handleDelete} disabled={isDeleting}>
+                  {isDeleting ? "Deleting..." : "Delete Media"}
+                </Button>
+              </Modal.Footer>
+            </Modal.Panel>
+          </Modal.Positioner>
+        </Modal.Portal>
+      </Modal.Root>
     </section>
   )
 }

--- a/src/screens/console-routes.ts
+++ b/src/screens/console-routes.ts
@@ -16,6 +16,7 @@ export const routes = {
     equipmentDetail: 'equipment/:id',
     broadcastOverview: 'broadcast',
     broadcastMedia: 'broadcast/media',
+    broadcastMediaDetail: 'broadcast/media/:id',
     broadcastPlaylists: 'broadcast/playlists',
     broadcastPlaylistDetail: 'broadcast/playlists/:id',
     broadcastStreams: 'broadcast/streams',

--- a/src/screens/dashboard/page.tsx
+++ b/src/screens/dashboard/page.tsx
@@ -189,7 +189,7 @@ export function DashboardScreen() {
                                 </div>
                                 <Button variant="ghost" icon={<ArrowRight />} iconPosition="trailing" onClick={() => navigate(`/${routes.requestsOverview}`)}>View all</Button>
                             </Card.Header>
-                            <Card.Content ghost className='flex flex-col gap-1.5'>
+                            <Card.Content ghost={overdueRequests.length > 0} className={overdueRequests.length > 0 ? 'flex flex-col gap-1.5' : ''}>
                                 {isLoadingActive ? (
                                     <div className="flex justify-center py-6"><Spinner /></div>
                                 ) : overdueRequests.length > 0 ? (
@@ -222,7 +222,7 @@ export function DashboardScreen() {
                                 </div>
                                 <Button variant="ghost" icon={<ArrowRight />} iconPosition="trailing" onClick={() => navigate(`/${routes.requestsOverview}`)}>View all</Button>
                             </Card.Header>
-                            <Card.Content ghost className='flex flex-col gap-1.5'>
+                            <Card.Content ghost={upcomingRequests.length > 0} className={upcomingRequests.length > 0 ? 'flex flex-col gap-1.5' : ''}>
                                 {isLoadingActive ? (
                                     <div className="flex justify-center py-6"><Spinner /></div>
                                 ) : upcomingRequests.length > 0 ? (

--- a/src/types/broadcast/stream.ts
+++ b/src/types/broadcast/stream.ts
@@ -60,6 +60,7 @@ export type YouTubeConnection = {
   channelTitle: string
   connectedBy: string
   createdAt: string
+  tokenExpiresAt: string
   presets: StreamPreset | null
 }
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -175,8 +175,9 @@ export default defineConfig(({ mode }) => {
           start_url: '/',
           scope: '/',
           display: 'standalone',
+          display_override: ['edge-to-edge', 'standalone'],
           orientation: 'any',
-          theme_color: '#E33483',
+          theme_color: '#ffffff',
           background_color: '#ffffff',
           icons: [
             { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png' },


### PR DESCRIPTION
## Summary
- **PWA native-feel polish.** Status bar / nav bar no longer painted brand pink — `theme-color` is white in light mode and `#171717` in dark, manifest opts into `display_override: edge-to-edge`, iOS uses `black-translucent` so content extends under the status bar, viewport pinned to disable user-scaling and tap-highlight is transparent. Topbar, main scroll area, and the mobile sidebar overlay all respect `env(safe-area-inset-*)`.
- **Media detail page + drawer affordances.** New screen at `broadcast/media/:id` (typography + dividers, matching the requests-detail pattern). The drawer header gained an expand (Maximize2) action that opens the new page, plus a delete (Trash2) action wired through a confirmation modal on the list page.
- **YouTube sync narrowed.** `syncStreamsFromYouTube` now only pulls `broadcastStatus=upcoming` and `broadcastStatus=active`; completed broadcasts are skipped, and the local cleanup pass preserves any stream already marked `complete` so prior streams stick around.
- **Phase-16 model update.** `YouTubeConnection` now exposes `tokenExpiresAt`; `fetchYouTubeConnection` selects `token_expires_at`. SQL migration committed under `docs/phases/`.
- **Dashboard empty-state consistency.** Overdue / Upcoming Requests cards now drop their `ghost` content treatment when empty so the empty box matches Events / Checklists / Playlists.

## Test plan
- [ ] Install the PWA on Android Chrome (122+) and confirm the status bar is white and the gesture nav doesn't crash into content.
- [ ] Install on iOS Safari and confirm content sits below the notch with no pink chrome.
- [ ] Open Media → list, click an item → drawer opens with X / Maximize / (Trash) buttons.
- [ ] From the drawer, hit expand → lands on `/broadcast/media/:id`; trash button opens confirm modal and deletes from the list.
- [ ] Sync YouTube streams; verify only upcoming + active broadcasts return and previously completed local streams remain.
- [ ] Run `phase-16-youtube-token-expiry.sql` on a DB without `token_expires_at`; confirm app still loads YouTube connection state.
- [ ] Dashboard with zero items in every section: requests cards now look like events / checklists / playlists cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)