### PR TITLE
fix: PWA edge-to-edge — drop invalid manifest field, unblock bleed

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,7 +11,7 @@
   <!-- iOS PWA meta -->
   <meta name="apple-mobile-web-app-capable" content="yes" />
   <meta name="mobile-web-app-capable" content="yes" />
-  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+  <meta name="apple-mobile-web-app-status-bar-style" content="default" />
   <meta name="apple-mobile-web-app-title" content="MOC Console" />
   <link rel="apple-touch-icon" sizes="180x180" href="/icons/apple-touch-icon.png" />
   <script src="https://mcp.figma.com/mcp/html-to-design/capture.js" async></script>

--- a/src/features/app-shell.tsx
+++ b/src/features/app-shell.tsx
@@ -158,7 +158,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                     <Breadcrumb.Root />
                 </TopBar>
 
-                <main className="area-content min-h-0 overflow-y-auto bg-[var(--background-color-primary)] pb-[env(safe-area-inset-bottom)]">
+                <main className="area-content min-h-0 overflow-y-auto bg-[var(--background-color-primary)]">
                     {children}
                 </main>
             </div>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -175,7 +175,6 @@ export default defineConfig(({ mode }) => {
           start_url: '/',
           scope: '/',
           display: 'standalone',
-          display_override: ['edge-to-edge', 'standalone'],
           orientation: 'any',
           theme_color: '#ffffff',
           background_color: '#ffffff',


### PR DESCRIPTION
## Summary
Follow-up to #13. Three real bugs in the prior native-feel pass, found via fresh research on current (2025) Chromium + iOS PWA behavior:

- **`display_override: ['edge-to-edge', 'standalone']` was invalid.** MDN's valid set is `browser | fullscreen | minimal-ui | standalone | tabbed | window-controls-overlay` — Chrome silently dropped the whole field. The Android edge-to-edge opt-in is just `viewport-fit=cover` on Chrome 135+ (April 2025), which we already have. Removed the bogus field.
- **iOS `apple-mobile-web-app-status-bar-style=black-translucent` always paints status-bar glyphs in white** — invisible on a white app body. Reverted to `default` so iOS shows a solid white status bar with dark glyphs (no iOS edge-to-edge, but readable).
- **`pb-[env(safe-area-inset-bottom)]` on `<main>` was letterboxing the scroll area.** Padding pulls content away from the edge instead of letting the bg bleed under the gesture chin. Removed; `<main>`'s white bg now paints to the very bottom edge and content scrolls under the Chrome 135+ chin overlay (gesture-nav devices).

## Platform caveats
- **Android 3-button nav** stays opaque regardless — the bottom transparency is only on **gesture nav** + Chrome ≥135.
- iOS + white app cannot have both true under-the-status-bar bleed AND dark glyphs (mutually exclusive). This PR picks dark glyphs.
- Manifest changes (theme_color, etc.) are cached at install time — the PWA must be uninstalled and reinstalled to pick them up.

Refs: [Chrome edge-to-edge guide](https://developer.chrome.com/docs/css-ui/edge-to-edge), [MDN display_override](https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Manifest/Reference/display_override).

## Test plan
- [ ] Uninstall the PWA, reinstall from this build.
- [ ] On an Android device using **gesture navigation** + Chrome ≥135: confirm bottom chin is a transparent overlay over white bg (not a black bar) and content scrolls under it.
- [ ] On an Android device using **3-button nav**: confirm the system bar is still opaque (expected — platform limitation), but content reaches the system bar with no letterboxing strip above it.
- [ ] On iOS Safari home-screen install: status bar is solid white with dark glyphs; no extra strip below it; bottom of scroll list reaches the home-indicator area.
- [ ] No regressions on the merged #13 work (media detail page, dashboard empty states, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)