### PR TITLE
feat: cue-sheet drawers, blank runs, equipment booking, data layer updates

### DIFF
--- a/api/zoom/oauth/exchange.ts
+++ b/api/zoom/oauth/exchange.ts
@@ -1,4 +1,4 @@
-import { exchangeZoomCode, resolveZoomOAuthConfig } from "../../../server/zoom-oauth"
+import { exchangeZoomCode, resolveZoomOAuthConfig } from "../../../server/zoom-oauth.js"
 
 type ApiRequest = {
   method?: string

--- a/api/zoom/oauth/refresh.ts
+++ b/api/zoom/oauth/refresh.ts
@@ -1,4 +1,4 @@
-import { refreshZoomToken, resolveZoomOAuthConfig } from "../../../server/zoom-oauth"
+import { refreshZoomToken, resolveZoomOAuthConfig } from "../../../server/zoom-oauth.js"
 
 type ApiRequest = {
   method?: string

--- a/api/zoom/oauth/revoke.ts
+++ b/api/zoom/oauth/revoke.ts
@@ -1,4 +1,4 @@
-import { resolveZoomOAuthConfig, revokeZoomAccessToken } from "../../../server/zoom-oauth"
+import { resolveZoomOAuthConfig, revokeZoomAccessToken } from "../../../server/zoom-oauth.js"
 
 type ApiRequest = {
   method?: string

--- a/api/zoom/v2/[...path].ts
+++ b/api/zoom/v2/[...path].ts
@@ -1,4 +1,4 @@
-import { proxyZoomApiRequest } from "../../../../server/zoom-api"
+import { proxyZoomApiRequest } from "../../../../server/zoom-api.js"
 
 type ApiRequest = {
   body?: Buffer | string

--- a/docs/phases/phase-10-rpcs.sql
+++ b/docs/phases/phase-10-rpcs.sql
@@ -156,3 +156,294 @@ BEGIN
   RETURN v_checklist_id;
 END;
 $$;
+
+-- 3. save_playlist_queue
+CREATE OR REPLACE FUNCTION public.save_playlist_queue(
+  p_playlist_id uuid,
+  p_cues jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  DELETE FROM public.queue
+  WHERE playlist_id = p_playlist_id;
+
+  INSERT INTO public.queue (id, playlist_id, media_id, sort_order, duration, disabled)
+  SELECT
+    cue.id,
+    p_playlist_id,
+    cue.media_id,
+    cue.sort_order,
+    cue.duration,
+    cue.disabled
+  FROM jsonb_to_recordset(coalesce(p_cues, '[]'::jsonb)) AS cue(
+    id uuid,
+    media_id uuid,
+    sort_order integer,
+    duration integer,
+    disabled boolean
+  );
+END;
+$$;
+
+-- 4. save_template_tracks
+CREATE OR REPLACE FUNCTION public.save_template_tracks(
+  p_event_template_id uuid,
+  p_tracks jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_track_ids uuid[];
+BEGIN
+  SELECT coalesce(array_agg(id), '{}')
+  INTO v_track_ids
+  FROM public.template_tracks
+  WHERE event_template_id = p_event_template_id;
+
+  IF cardinality(v_track_ids) > 0 THEN
+    DELETE FROM public.template_cues
+    WHERE template_track_id = ANY(v_track_ids);
+  END IF;
+
+  DELETE FROM public.template_tracks
+  WHERE event_template_id = p_event_template_id;
+
+  INSERT INTO public.template_tracks (id, event_template_id, name, color_id, sort_order)
+  SELECT
+    track.id,
+    p_event_template_id,
+    track.name,
+    colors.id,
+    track.sort_order
+  FROM jsonb_to_recordset(coalesce(p_tracks, '[]'::jsonb)) AS track(
+    id uuid,
+    name text,
+    color_key text,
+    sort_order integer,
+    cues jsonb
+  )
+  JOIN public.colors ON colors.key = track.color_key;
+
+  INSERT INTO public.template_cues (id, template_track_id, label, start, duration, type, assignee, notes)
+  SELECT
+    cue.id,
+    (track.value->>'id')::uuid,
+    cue.label,
+    cue.start,
+    cue.duration,
+    cue.type,
+    cue.assignee,
+    cue.notes
+  FROM jsonb_array_elements(coalesce(p_tracks, '[]'::jsonb)) AS track(value)
+  CROSS JOIN LATERAL jsonb_to_recordset(coalesce(track.value->'cues', '[]'::jsonb)) AS cue(
+    id uuid,
+    label text,
+    start integer,
+    duration integer,
+    type public.cue_type,
+    assignee text,
+    notes text
+  );
+END;
+$$;
+
+-- 5. save_event_tracks
+CREATE OR REPLACE FUNCTION public.save_event_tracks(
+  p_event_id uuid,
+  p_tracks jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+DECLARE
+  v_track_ids uuid[];
+BEGIN
+  SELECT coalesce(array_agg(id), '{}')
+  INTO v_track_ids
+  FROM public.tracks
+  WHERE event_id = p_event_id;
+
+  IF cardinality(v_track_ids) > 0 THEN
+    DELETE FROM public.cues
+    WHERE track_id = ANY(v_track_ids);
+  END IF;
+
+  DELETE FROM public.tracks
+  WHERE event_id = p_event_id;
+
+  INSERT INTO public.tracks (id, event_id, name, color_id, sort_order)
+  SELECT
+    track.id,
+    p_event_id,
+    track.name,
+    colors.id,
+    track.sort_order
+  FROM jsonb_to_recordset(coalesce(p_tracks, '[]'::jsonb)) AS track(
+    id uuid,
+    name text,
+    color_key text,
+    sort_order integer,
+    cues jsonb
+  )
+  JOIN public.colors ON colors.key = track.color_key;
+
+  INSERT INTO public.cues (id, track_id, label, start, duration, type, assignee, notes)
+  SELECT
+    cue.id,
+    (track.value->>'id')::uuid,
+    cue.label,
+    cue.start,
+    cue.duration,
+    cue.type,
+    cue.assignee,
+    cue.notes
+  FROM jsonb_array_elements(coalesce(p_tracks, '[]'::jsonb)) AS track(value)
+  CROSS JOIN LATERAL jsonb_to_recordset(coalesce(track.value->'cues', '[]'::jsonb)) AS cue(
+    id uuid,
+    label text,
+    start integer,
+    duration integer,
+    type public.cue_type,
+    assignee text,
+    notes text
+  );
+END;
+$$;
+
+-- 6. save_template_checklist_structure
+-- Drop both possible signatures first so PostgREST/Supabase schema cache
+-- doesn't keep resolving an older parameter order.
+DROP FUNCTION IF EXISTS public.save_template_checklist_structure(uuid, jsonb);
+DROP FUNCTION IF EXISTS public.save_template_checklist_structure(jsonb, uuid);
+
+CREATE OR REPLACE FUNCTION public.save_template_checklist_structure(
+  p_checklist_template_id uuid,
+  p_checklist jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  DELETE FROM public.template_items
+  WHERE checklist_template_id = p_checklist_template_id;
+
+  DELETE FROM public.template_sections
+  WHERE checklist_template_id = p_checklist_template_id;
+
+  INSERT INTO public.template_sections (id, checklist_template_id, name, sort_order)
+  SELECT
+    section.id,
+    p_checklist_template_id,
+    section.name,
+    section.sort_order
+  FROM jsonb_to_recordset(coalesce(p_checklist->'sections', '[]'::jsonb)) AS section(
+    id uuid,
+    name text,
+    sort_order integer,
+    items jsonb
+  );
+
+  INSERT INTO public.template_items (id, checklist_template_id, template_section_id, label, sort_order)
+  SELECT
+    item.id,
+    p_checklist_template_id,
+    NULL,
+    item.label,
+    item.sort_order
+  FROM jsonb_to_recordset(coalesce(p_checklist->'items', '[]'::jsonb)) AS item(
+    id uuid,
+    label text,
+    checked boolean,
+    sort_order integer
+  );
+
+  INSERT INTO public.template_items (id, checklist_template_id, template_section_id, label, sort_order)
+  SELECT
+    item.id,
+    p_checklist_template_id,
+    (section.value->>'id')::uuid,
+    item.label,
+    item.sort_order
+  FROM jsonb_array_elements(coalesce(p_checklist->'sections', '[]'::jsonb)) AS section(value)
+  CROSS JOIN LATERAL jsonb_to_recordset(coalesce(section.value->'items', '[]'::jsonb)) AS item(
+    id uuid,
+    label text,
+    checked boolean,
+    sort_order integer
+  );
+END;
+$$;
+
+-- 7. save_checklist_structure
+-- Drop both possible signatures first so PostgREST/Supabase schema cache
+-- doesn't keep resolving an older parameter order.
+DROP FUNCTION IF EXISTS public.save_checklist_structure(uuid, jsonb);
+DROP FUNCTION IF EXISTS public.save_checklist_structure(jsonb, uuid);
+
+CREATE OR REPLACE FUNCTION public.save_checklist_structure(
+  p_checklist_id uuid,
+  p_checklist jsonb
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY INVOKER
+AS $$
+BEGIN
+  DELETE FROM public.checklist_items
+  WHERE checklist_id = p_checklist_id;
+
+  DELETE FROM public.checklist_sections
+  WHERE checklist_id = p_checklist_id;
+
+  INSERT INTO public.checklist_sections (id, checklist_id, name, sort_order)
+  SELECT
+    section.id,
+    p_checklist_id,
+    section.name,
+    section.sort_order
+  FROM jsonb_to_recordset(coalesce(p_checklist->'sections', '[]'::jsonb)) AS section(
+    id uuid,
+    name text,
+    sort_order integer,
+    items jsonb
+  );
+
+  INSERT INTO public.checklist_items (id, checklist_id, section_id, label, checked, sort_order)
+  SELECT
+    item.id,
+    p_checklist_id,
+    NULL,
+    item.label,
+    item.checked,
+    item.sort_order
+  FROM jsonb_to_recordset(coalesce(p_checklist->'items', '[]'::jsonb)) AS item(
+    id uuid,
+    label text,
+    checked boolean,
+    sort_order integer
+  );
+
+  INSERT INTO public.checklist_items (id, checklist_id, section_id, label, checked, sort_order)
+  SELECT
+    item.id,
+    p_checklist_id,
+    (section.value->>'id')::uuid,
+    item.label,
+    item.checked,
+    item.sort_order
+  FROM jsonb_array_elements(coalesce(p_checklist->'sections', '[]'::jsonb)) AS section(value)
+  CROSS JOIN LATERAL jsonb_to_recordset(coalesce(section.value->'items', '[]'::jsonb)) AS item(
+    id uuid,
+    label text,
+    checked boolean,
+    sort_order integer
+  );
+END;
+$$;

--- a/src/data/fetch-assignees.ts
+++ b/src/data/fetch-assignees.ts
@@ -28,10 +28,12 @@ function mapUserRow(row: UserRow): User {
 }
 
 export async function fetchAssigneesByRequestId(requestId: string): Promise<ResolvedAssignee[]> {
+  const workspaceId = await getCurrentWorkspaceId();
   const { data, error } = await supabase
     .from("request_assignees")
-    .select("duty, users(id, name, surname, email, telegram_chat_id)")
-    .eq("request_id", requestId);
+    .select("duty, users(id, name, surname, email, telegram_chat_id), requests!inner(workspace_id)")
+    .eq("request_id", requestId)
+    .eq("requests.workspace_id", workspaceId);
 
   if (error) {
     throw new Error(error.message);

--- a/src/data/fetch-broadcast.ts
+++ b/src/data/fetch-broadcast.ts
@@ -121,10 +121,12 @@ export async function fetchMedia(): Promise<MediaItem[]> {
 }
 
 export async function fetchMediaById(id: string): Promise<MediaItem | undefined> {
+  const workspaceId = await getCurrentWorkspaceId();
   const { data, error } = await supabase
     .from("media")
     .select("id, name, type, url, thumbnail_url, created_at")
     .eq("id", id)
+    .eq("workspace_id", workspaceId)
     .maybeSingle();
 
   if (error) {

--- a/src/data/fetch-cue-sheet.ts
+++ b/src/data/fetch-cue-sheet.ts
@@ -244,16 +244,19 @@ export async function fetchCueSheetEvents(): Promise<CueSheetEvent[]> {
 }
 
 export async function fetchCueSheetEventById(id: string): Promise<CueSheetEvent | undefined> {
+  const workspaceId = await getCurrentWorkspaceId();
   const [templateResult, runResult] = await Promise.all([
     supabase
       .from("event_templates")
       .select("id, title, description, duration, created_at, updated_at")
       .eq("id", id)
+      .eq("workspace_id", workspaceId)
       .maybeSingle(),
     supabase
       .from("events")
       .select("id, title, description, scheduled_at, duration, created_at, updated_at")
       .eq("id", id)
+      .eq("workspace_id", workspaceId)
       .maybeSingle(),
   ]);
 
@@ -296,28 +299,46 @@ export async function fetchCueSheetEventById(id: string): Promise<CueSheetEvent 
 }
 
 export async function fetchCueSheetChecklists(): Promise<Checklist[]> {
-  const [[templateResult, runResult], [templateSectionsResult, templateItemsResult, sectionsResult, itemsResult]] = await Promise.all([
-    fetchWorkspaceScopedChecklists(),
-    Promise.all([
-      supabase.from("template_sections").select("id, checklist_template_id, name, sort_order"),
-      supabase.from("template_items").select("id, checklist_template_id, template_section_id, label, sort_order"),
-      supabase.from("checklist_sections").select("id, checklist_id, name, sort_order"),
-      supabase.from("checklist_items").select("id, checklist_id, section_id, label, checked, sort_order"),
-    ]),
-  ]);
+  const [templateResult, runResult] = await fetchWorkspaceScopedChecklists();
 
-  for (const result of [templateResult, runResult, templateSectionsResult, templateItemsResult, sectionsResult, itemsResult]) {
+  for (const result of [templateResult, runResult]) {
     if (result.error) {
       throw new Error(result.error.message);
     }
   }
 
-  const templates = ((templateResult.data ?? []) as ChecklistTemplateRow[]).map((template) => mapTemplateChecklist(
+  const templatesData = (templateResult.data ?? []) as ChecklistTemplateRow[];
+  const runsData = (runResult.data ?? []) as ChecklistRunRow[];
+  const templateIds = templatesData.map((template) => template.id);
+  const runIds = runsData.map((run) => run.id);
+
+  const [templateSectionsResult, templateItemsResult, sectionsResult, itemsResult] = await Promise.all([
+    templateIds.length > 0
+      ? supabase.from("template_sections").select("id, checklist_template_id, name, sort_order").in("checklist_template_id", templateIds)
+      : Promise.resolve({ data: [], error: null }),
+    templateIds.length > 0
+      ? supabase.from("template_items").select("id, checklist_template_id, template_section_id, label, sort_order").in("checklist_template_id", templateIds)
+      : Promise.resolve({ data: [], error: null }),
+    runIds.length > 0
+      ? supabase.from("checklist_sections").select("id, checklist_id, name, sort_order").in("checklist_id", runIds)
+      : Promise.resolve({ data: [], error: null }),
+    runIds.length > 0
+      ? supabase.from("checklist_items").select("id, checklist_id, section_id, label, checked, sort_order").in("checklist_id", runIds)
+      : Promise.resolve({ data: [], error: null }),
+  ]);
+
+  for (const result of [templateSectionsResult, templateItemsResult, sectionsResult, itemsResult]) {
+    if (result.error) {
+      throw new Error(result.error.message);
+    }
+  }
+
+  const templates = templatesData.map((template) => mapTemplateChecklist(
     template,
     (templateSectionsResult.data ?? []) as TemplateSectionRow[],
     (templateItemsResult.data ?? []) as TemplateItemRow[],
   ));
-  const runs = ((runResult.data ?? []) as ChecklistRunRow[]).map((run) => mapRunChecklist(
+  const runs = runsData.map((run) => mapRunChecklist(
     run,
     (sectionsResult.data ?? []) as ChecklistSectionRow[],
     (itemsResult.data ?? []) as ChecklistItemRow[],
@@ -332,29 +353,58 @@ export async function fetchCueSheetChecklistById(id: string): Promise<Checklist 
 }
 
 export async function fetchCueSheetTracks(): Promise<Record<string, Track[]>> {
+  const workspaceId = await getCurrentWorkspaceId();
+  const [templateOwnersResult, eventOwnersResult] = await Promise.all([
+    supabase
+      .from("event_templates")
+      .select("id")
+      .eq("workspace_id", workspaceId),
+    supabase
+      .from("events")
+      .select("id")
+      .eq("workspace_id", workspaceId),
+  ]);
+
+  if (templateOwnersResult.error) {
+    throw new Error(templateOwnersResult.error.message);
+  }
+
+  if (eventOwnersResult.error) {
+    throw new Error(eventOwnersResult.error.message);
+  }
+
+  const templateOwnerIds = ((templateOwnersResult.data ?? []) as Array<{ id: string }>).map((row) => row.id);
+  const eventOwnerIds = ((eventOwnersResult.data ?? []) as Array<{ id: string }>).map((row) => row.id);
+
   const [templateTracksResult, eventTracksResult] = await Promise.all([
-    supabase
-      .from("template_tracks")
-      .select(`
-        id,
-        event_template_id,
-        name,
-        sort_order,
-        colors:color_id(key),
-        template_cues(id, label, start, duration, type, assignee, notes)
-      `)
-      .order("sort_order", { ascending: true }),
-    supabase
-      .from("tracks")
-      .select(`
-        id,
-        event_id,
-        name,
-        sort_order,
-        colors:color_id(key),
-        cues(id, label, start, duration, type, assignee, notes)
-      `)
-      .order("sort_order", { ascending: true }),
+    templateOwnerIds.length > 0
+      ? supabase
+          .from("template_tracks")
+          .select(`
+            id,
+            event_template_id,
+            name,
+            sort_order,
+            colors:color_id(key),
+            template_cues(id, label, start, duration, type, assignee, notes)
+          `)
+          .in("event_template_id", templateOwnerIds)
+          .order("sort_order", { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
+    eventOwnerIds.length > 0
+      ? supabase
+          .from("tracks")
+          .select(`
+            id,
+            event_id,
+            name,
+            sort_order,
+            colors:color_id(key),
+            cues(id, label, start, duration, type, assignee, notes)
+          `)
+          .in("event_id", eventOwnerIds)
+          .order("sort_order", { ascending: true })
+      : Promise.resolve({ data: [], error: null }),
   ]);
 
   if (templateTracksResult.error) {

--- a/src/data/fetch-streams.ts
+++ b/src/data/fetch-streams.ts
@@ -107,12 +107,14 @@ export async function fetchStreams(): Promise<Stream[]> {
 }
 
 export async function fetchStreamById(id: string): Promise<Stream | undefined> {
+  const workspaceId = await getCurrentWorkspaceId()
   const { data, error } = await supabase
     .from("streams")
     .select(
       "id, workspace_id, youtube_broadcast_id, youtube_stream_id, title, description, thumbnail_url, privacy_status, is_for_kids, scheduled_start_time, actual_start_time, actual_end_time, stream_status, stream_url, stream_key, ingestion_url, category_id, tags, latency_preference, enable_dvr, enable_embed, enable_auto_start, enable_auto_stop, playlist_id, created_by, created_at, updated_at",
     )
     .eq("id", id)
+    .eq("workspace_id", workspaceId)
     .maybeSingle()
 
   if (error) {

--- a/src/data/fetch-workspaces.ts
+++ b/src/data/fetch-workspaces.ts
@@ -17,22 +17,6 @@ export type WorkspaceDirectory = {
   memberships: WorkspaceMembership[];
 };
 
-const fallbackWorkspace: Workspace = {
-  id: "default-workspace",
-  name: "Default Workspace",
-  slug: "default-workspace",
-};
-
-function getFallbackDirectory(userIds: string[]): WorkspaceDirectory {
-  return {
-    workspaces: [fallbackWorkspace],
-    memberships: userIds.map((userId) => ({
-      workspaceId: fallbackWorkspace.id,
-      userId,
-    })),
-  };
-}
-
 export async function fetchWorkspaceDirectory(userIds: string[]): Promise<WorkspaceDirectory> {
   if (userIds.length === 0) {
     return { workspaces: [], memberships: [] };
@@ -43,8 +27,12 @@ export async function fetchWorkspaceDirectory(userIds: string[]): Promise<Worksp
     supabase.from("workspace_users").select("workspace_id, user_id").in("user_id", userIds),
   ]);
 
-  if (workspaceError || membershipError || !(workspaceData && workspaceData.length > 0)) {
-    return getFallbackDirectory(userIds);
+  if (workspaceError) {
+    throw new Error(workspaceError.message);
+  }
+
+  if (membershipError) {
+    throw new Error(membershipError.message);
   }
 
   return {

--- a/src/data/fetch-zoom.ts
+++ b/src/data/fetch-zoom.ts
@@ -108,10 +108,12 @@ export async function fetchZoomMeetings(): Promise<ZoomMeeting[]> {
 }
 
 export async function fetchZoomMeetingById(id: string): Promise<ZoomMeeting | undefined> {
+  const workspaceId = await getCurrentWorkspaceId()
   const { data, error } = await supabase
     .from("zoom_meetings")
     .select(MEETING_COLUMNS)
     .eq("id", id)
+    .eq("workspace_id", workspaceId)
     .maybeSingle()
 
   if (error) {

--- a/src/data/mutate-booking.ts
+++ b/src/data/mutate-booking.ts
@@ -1,5 +1,75 @@
 import type { Booking } from "@/types/equipment/booking";
 import { supabase } from "@/lib/supabase";
+import { getCurrentWorkspaceId } from "./current-workspace";
+
+function getBookingDuration(checkedOutAt: string, returnedAt: string | null, expectedReturnAt: string) {
+  const start = new Date(checkedOutAt).getTime();
+  const end = new Date(returnedAt ?? expectedReturnAt).getTime();
+  const diffMs = Math.max(end - start, 0);
+  const totalHours = Math.round(diffMs / (1000 * 60 * 60));
+
+  if (totalHours >= 24) {
+    const days = Math.round(totalHours / 24);
+    return `${days} ${days === 1 ? "day" : "days"}`;
+  }
+
+  const hours = Math.max(totalHours, 1);
+  return `${hours} ${hours === 1 ? "hour" : "hours"}`;
+}
+
+function mapBookingRow(row: Record<string, unknown>, fallbackEquipmentName: string): Booking {
+  const equipment = Array.isArray(row.equipment) ? row.equipment[0] : row.equipment;
+
+  return {
+    id: row.id as string,
+    equipmentId: row.equipment_id as string,
+    equipmentName: (equipment as { name: string } | undefined)?.name ?? fallbackEquipmentName,
+    bookedBy: row.booked_by as string,
+    checkedOutDate: row.checked_out_at as string,
+    expectedReturnAt: row.expected_return_at as string,
+    returnedDate: row.returned_at as string | null,
+    duration: getBookingDuration(
+      row.checked_out_at as string,
+      row.returned_at as string | null,
+      row.expected_return_at as string,
+    ),
+    notes: (row.notes as string) ?? "",
+    status: row.status as Booking["status"],
+  };
+}
+
+export type CreateBookingParams = {
+  equipmentId: string;
+  equipmentName: string;
+  bookedBy: string;
+  checkedOutDate: string;
+  expectedReturnAt: string;
+  notes: string;
+  status: Booking["status"];
+};
+
+export async function createBooking(params: CreateBookingParams): Promise<Booking> {
+  const workspaceId = await getCurrentWorkspaceId();
+  const { data, error } = await supabase
+    .from("bookings")
+    .insert({
+      workspace_id: workspaceId,
+      equipment_id: params.equipmentId,
+      booked_by: params.bookedBy,
+      checked_out_at: params.checkedOutDate,
+      expected_return_at: params.expectedReturnAt,
+      notes: params.notes || null,
+      status: params.status,
+    })
+    .select("id, equipment_id, booked_by, checked_out_at, expected_return_at, returned_at, notes, status, equipment:equipment_id(id, name)")
+    .single();
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return mapBookingRow(data as Record<string, unknown>, params.equipmentName);
+}
 
 export async function updateBooking(booking: Booking): Promise<Booking> {
   const { data, error } = await supabase
@@ -20,19 +90,16 @@ export async function updateBooking(booking: Booking): Promise<Booking> {
     throw new Error(error.message);
   }
 
-  const row = data as Record<string, unknown>;
-  const equipment = Array.isArray(row.equipment) ? row.equipment[0] : row.equipment;
+  return mapBookingRow(data as Record<string, unknown>, booking.equipmentName);
+}
 
-  return {
-    id: row.id as string,
-    equipmentId: row.equipment_id as string,
-    equipmentName: (equipment as { name: string })?.name ?? booking.equipmentName,
-    bookedBy: row.booked_by as string,
-    checkedOutDate: row.checked_out_at as string,
-    expectedReturnAt: row.expected_return_at as string,
-    returnedDate: (row.returned_at as string | null),
-    duration: booking.duration,
-    notes: (row.notes as string) ?? "",
-    status: row.status as Booking["status"],
-  };
+export async function deleteBooking(id: string): Promise<void> {
+  const { error } = await supabase
+    .from("bookings")
+    .delete()
+    .eq("id", id);
+
+  if (error) {
+    throw new Error(error.message);
+  }
 }

--- a/src/data/mutate-broadcast.ts
+++ b/src/data/mutate-broadcast.ts
@@ -26,6 +26,22 @@ function mapMediaRow(row: MediaRow, fallbackDuration: number | null): MediaItem 
   };
 }
 
+function getManagedMediaStoragePath(url: string): string | null {
+  const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+
+  if (!supabaseUrl) {
+    return null;
+  }
+
+  const publicPrefix = `${supabaseUrl}/storage/v1/object/public/media/`;
+
+  if (!url.startsWith(publicPrefix)) {
+    return null;
+  }
+
+  return decodeURIComponent(url.slice(publicPrefix.length));
+}
+
 export async function updatePlaylist(playlist: Playlist): Promise<Playlist> {
   const workspaceId = await getCurrentWorkspaceId();
   const payload = {
@@ -71,29 +87,16 @@ export async function deletePlaylist(id: string): Promise<void> {
 }
 
 export async function updatePlaylistCues(playlistId: string, cues: Cue[]): Promise<Cue[]> {
-  const deleteResult = await supabase
-    .from("queue")
-    .delete()
-    .eq("playlist_id", playlistId);
-
-  if (deleteResult.error) {
-    throw new Error(deleteResult.error.message);
-  }
-
-  if (cues.length === 0) {
-    return [];
-  }
-
-  const { error } = await supabase
-    .from("queue")
-    .insert(cues.map((cue, index) => ({
+  const { error } = await supabase.rpc("save_playlist_queue", {
+    p_playlist_id: playlistId,
+    p_cues: cues.map((cue, index) => ({
       id: cue.id,
-      playlist_id: playlistId,
       media_id: cue.mediaItemId,
       sort_order: index + 1,
       duration: cue.durationOverride,
       disabled: cue.disabled ?? false,
-    })));
+    })),
+  });
 
   if (error) {
     throw new Error(error.message);
@@ -151,11 +154,23 @@ export async function createMediaItem(item: MediaItem): Promise<MediaItem> {
   return mapMediaRow(data as MediaRow, item.duration);
 }
 
-export async function deleteMediaItem(id: string): Promise<void> {
+export async function deleteMediaItem(item: Pick<MediaItem, "id" | "url">): Promise<void> {
+  const storagePath = getManagedMediaStoragePath(item.url);
+
+  if (storagePath) {
+    const { error: storageError } = await supabase.storage
+      .from("media")
+      .remove([storagePath]);
+
+    if (storageError) {
+      throw new Error(storageError.message);
+    }
+  }
+
   const { error } = await supabase
     .from("media")
     .delete()
-    .eq("id", id);
+    .eq("id", item.id);
 
   if (error) {
     throw new Error(error.message);

--- a/src/data/mutate-cue-sheet.ts
+++ b/src/data/mutate-cue-sheet.ts
@@ -3,293 +3,111 @@ import { supabase } from "@/lib/supabase";
 import { getCurrentWorkspaceId } from "./current-workspace";
 import { fetchCueSheetChecklistById, fetchCueSheetEventById, fetchCueSheetTracksByEventId } from "./fetch-cue-sheet";
 
-async function resolveColorIdByKey(colorKey: Track["colorKey"]) {
-  const { data, error } = await supabase
-    .from("colors")
-    .select("id")
-    .eq("key", colorKey)
-    .maybeSingle();
+async function replaceTemplateTracks(eventTemplateId: string, tracks: Track[]) {
+  const { error } = await supabase.rpc("save_template_tracks", {
+    p_event_template_id: eventTemplateId,
+    p_tracks: tracks.map((track, index) => ({
+      id: track.id,
+      name: track.name,
+      color_key: track.colorKey,
+      sort_order: index + 1,
+      cues: track.cues.map((cue) => ({
+        id: cue.id,
+        label: cue.label,
+        start: cue.startMin,
+        duration: cue.durationMin,
+        type: cue.type,
+        assignee: cue.assignee ?? null,
+        notes: cue.notes ?? null,
+      })),
+    })),
+  });
 
   if (error) {
     throw new Error(error.message);
   }
-
-  if (!data?.id) {
-    throw new Error(`Track color '${colorKey}' not found`);
-  }
-
-  return data.id as string;
-}
-
-async function replaceTemplateTracks(eventTemplateId: string, tracks: Track[]) {
-  const existingResult = await supabase
-    .from("template_tracks")
-    .select("id")
-    .eq("event_template_id", eventTemplateId);
-
-  if (existingResult.error) {
-    throw new Error(existingResult.error.message);
-  }
-
-  const existingTrackIds = ((existingResult.data ?? []) as Array<{ id: string }>).map((track) => track.id);
-
-  if (existingTrackIds.length > 0) {
-    const deleteCuesResult = await supabase
-      .from("template_cues")
-      .delete()
-      .in("template_track_id", existingTrackIds);
-
-    if (deleteCuesResult.error) {
-      throw new Error(deleteCuesResult.error.message);
-    }
-  }
-
-  const deleteTracksResult = await supabase
-    .from("template_tracks")
-    .delete()
-    .eq("event_template_id", eventTemplateId);
-
-  if (deleteTracksResult.error) {
-    throw new Error(deleteTracksResult.error.message);
-  }
-
-  for (const [trackIndex, track] of tracks.entries()) {
-    const colorId = await resolveColorIdByKey(track.colorKey);
-    const trackInsert = await supabase
-      .from("template_tracks")
-      .insert({
-        id: track.id,
-        event_template_id: eventTemplateId,
-        name: track.name,
-        color_id: colorId,
-        sort_order: trackIndex + 1,
-      });
-
-    if (trackInsert.error) {
-      throw new Error(trackInsert.error.message);
-    }
-
-    if (track.cues.length === 0) {
-      continue;
-    }
-
-    const cueInsert = await supabase
-      .from("template_cues")
-      .insert(track.cues.map((cue) => ({
-        id: cue.id,
-        template_track_id: track.id,
-        label: cue.label,
-        start: cue.startMin,
-        duration: cue.durationMin,
-        type: cue.type,
-        assignee: cue.assignee ?? null,
-        notes: cue.notes ?? null,
-      })));
-
-    if (cueInsert.error) {
-      throw new Error(cueInsert.error.message);
-    }
-  }
 }
 
 async function replaceEventTracks(eventId: string, tracks: Track[]) {
-  const existingResult = await supabase
-    .from("tracks")
-    .select("id")
-    .eq("event_id", eventId);
-
-  if (existingResult.error) {
-    throw new Error(existingResult.error.message);
-  }
-
-  const existingTrackIds = ((existingResult.data ?? []) as Array<{ id: string }>).map((track) => track.id);
-
-  if (existingTrackIds.length > 0) {
-    const deleteCuesResult = await supabase
-      .from("cues")
-      .delete()
-      .in("track_id", existingTrackIds);
-
-    if (deleteCuesResult.error) {
-      throw new Error(deleteCuesResult.error.message);
-    }
-  }
-
-  const deleteTracksResult = await supabase
-    .from("tracks")
-    .delete()
-    .eq("event_id", eventId);
-
-  if (deleteTracksResult.error) {
-    throw new Error(deleteTracksResult.error.message);
-  }
-
-  for (const [trackIndex, track] of tracks.entries()) {
-    const colorId = await resolveColorIdByKey(track.colorKey);
-    const trackInsert = await supabase
-      .from("tracks")
-      .insert({
-        id: track.id,
-        event_id: eventId,
-        name: track.name,
-        color_id: colorId,
-        sort_order: trackIndex + 1,
-      });
-
-    if (trackInsert.error) {
-      throw new Error(trackInsert.error.message);
-    }
-
-    if (track.cues.length === 0) {
-      continue;
-    }
-
-    const cueInsert = await supabase
-      .from("cues")
-      .insert(track.cues.map((cue) => ({
+  const { error } = await supabase.rpc("save_event_tracks", {
+    p_event_id: eventId,
+    p_tracks: tracks.map((track, index) => ({
+      id: track.id,
+      name: track.name,
+      color_key: track.colorKey,
+      sort_order: index + 1,
+      cues: track.cues.map((cue) => ({
         id: cue.id,
-        track_id: track.id,
         label: cue.label,
         start: cue.startMin,
         duration: cue.durationMin,
         type: cue.type,
         assignee: cue.assignee ?? null,
         notes: cue.notes ?? null,
-      })));
+      })),
+    })),
+  });
 
-    if (cueInsert.error) {
-      throw new Error(cueInsert.error.message);
-    }
+  if (error) {
+    throw new Error(error.message);
   }
 }
 
 async function replaceTemplateChecklistStructure(checklistTemplateId: string, checklist: Checklist) {
-  const deleteItemsResult = await supabase
-    .from("template_items")
-    .delete()
-    .eq("checklist_template_id", checklistTemplateId);
-
-  if (deleteItemsResult.error) {
-    throw new Error(deleteItemsResult.error.message);
-  }
-
-  const deleteSectionsResult = await supabase
-    .from("template_sections")
-    .delete()
-    .eq("checklist_template_id", checklistTemplateId);
-
-  if (deleteSectionsResult.error) {
-    throw new Error(deleteSectionsResult.error.message);
-  }
-
-  if (checklist.sections.length > 0) {
-    const sectionInsert = await supabase
-      .from("template_sections")
-      .insert(checklist.sections.map((section, index) => ({
-        id: section.id,
-        checklist_template_id: checklistTemplateId,
-        name: section.name,
+  const { error } = await supabase.rpc("save_template_checklist_structure", {
+    p_checklist_template_id: checklistTemplateId,
+    p_checklist: {
+      items: checklist.items.map((item, index) => ({
+        id: item.id,
+        label: item.label,
+        checked: false,
         sort_order: index + 1,
-      })));
+      })),
+      sections: checklist.sections.map((section, sectionIndex) => ({
+        id: section.id,
+        name: section.name,
+        sort_order: sectionIndex + 1,
+        items: section.items.map((item, itemIndex) => ({
+          id: item.id,
+          label: item.label,
+          checked: false,
+          sort_order: itemIndex + 1,
+        })),
+      })),
+    },
+  });
 
-    if (sectionInsert.error) {
-      throw new Error(sectionInsert.error.message);
-    }
-  }
-
-  const itemsPayload = [
-    ...checklist.items.map((item, index) => ({
-      id: item.id,
-      checklist_template_id: checklistTemplateId,
-      template_section_id: null,
-      label: item.label,
-      sort_order: index + 1,
-    })),
-    ...checklist.sections.flatMap((section) => section.items.map((item, index) => ({
-      id: item.id,
-      checklist_template_id: checklistTemplateId,
-      template_section_id: section.id,
-      label: item.label,
-      sort_order: index + 1,
-    }))),
-  ];
-
-  if (itemsPayload.length === 0) {
-    return;
-  }
-
-  const itemInsert = await supabase
-    .from("template_items")
-    .insert(itemsPayload);
-
-  if (itemInsert.error) {
-    throw new Error(itemInsert.error.message);
+  if (error) {
+    throw new Error(error.message);
   }
 }
 
 async function replaceChecklistStructure(checklistId: string, checklist: Checklist) {
-  const deleteItemsResult = await supabase
-    .from("checklist_items")
-    .delete()
-    .eq("checklist_id", checklistId);
-
-  if (deleteItemsResult.error) {
-    throw new Error(deleteItemsResult.error.message);
-  }
-
-  const deleteSectionsResult = await supabase
-    .from("checklist_sections")
-    .delete()
-    .eq("checklist_id", checklistId);
-
-  if (deleteSectionsResult.error) {
-    throw new Error(deleteSectionsResult.error.message);
-  }
-
-  if (checklist.sections.length > 0) {
-    const sectionInsert = await supabase
-      .from("checklist_sections")
-      .insert(checklist.sections.map((section, index) => ({
-        id: section.id,
-        checklist_id: checklistId,
-        name: section.name,
+  const { error } = await supabase.rpc("save_checklist_structure", {
+    p_checklist_id: checklistId,
+    p_checklist: {
+      items: checklist.items.map((item, index) => ({
+        id: item.id,
+        label: item.label,
+        checked: item.checked,
         sort_order: index + 1,
-      })));
+      })),
+      sections: checklist.sections.map((section, sectionIndex) => ({
+        id: section.id,
+        name: section.name,
+        sort_order: sectionIndex + 1,
+        items: section.items.map((item, itemIndex) => ({
+          id: item.id,
+          label: item.label,
+          checked: item.checked,
+          sort_order: itemIndex + 1,
+        })),
+      })),
+    },
+  });
 
-    if (sectionInsert.error) {
-      throw new Error(sectionInsert.error.message);
-    }
-  }
-
-  const itemsPayload = [
-    ...checklist.items.map((item, index) => ({
-      id: item.id,
-      checklist_id: checklistId,
-      section_id: null,
-      label: item.label,
-      checked: item.checked,
-      sort_order: index + 1,
-    })),
-    ...checklist.sections.flatMap((section) => section.items.map((item, index) => ({
-      id: item.id,
-      checklist_id: checklistId,
-      section_id: section.id,
-      label: item.label,
-      checked: item.checked,
-      sort_order: index + 1,
-    }))),
-  ];
-
-  if (itemsPayload.length === 0) {
-    return;
-  }
-
-  const itemInsert = await supabase
-    .from("checklist_items")
-    .insert(itemsPayload);
-
-  if (itemInsert.error) {
-    throw new Error(itemInsert.error.message);
+  if (error) {
+    throw new Error(error.message);
   }
 }
 
@@ -429,12 +247,37 @@ export async function saveCueSheetTracks(event: Pick<CueSheetEvent, "id" | "kind
   return fetchCueSheetTracksByEventId(event.id);
 }
 
-export async function createCueSheetEventInstance(template: CueSheetEvent): Promise<CueSheetEvent> {
+export type CreateEventInstanceOverrides = {
+  title?: string;
+  description?: string;
+  scheduledAt?: string;
+};
+
+export type CreateBlankEventInput = {
+  title: string;
+  description: string;
+  duration: number;
+  scheduledAt: string;
+};
+
+export type CreateChecklistInstanceOverrides = {
+  name?: string;
+  description?: string;
+  scheduledAt?: string;
+};
+
+export type CreateBlankChecklistInput = {
+  name: string;
+  description: string;
+  scheduledAt: string;
+};
+
+export async function createCueSheetEventInstance(template: CueSheetEvent, overrides: CreateEventInstanceOverrides = {}): Promise<CueSheetEvent> {
   const { data, error } = await supabase.rpc("create_event_from_template", {
     p_template_id: template.id,
-    p_scheduled_at: new Date().toISOString(),
-    p_title: `${template.title} Run`,
-    p_description: template.description,
+    p_scheduled_at: overrides.scheduledAt ?? new Date().toISOString(),
+    p_title: overrides.title ?? `${template.title} Run`,
+    p_description: overrides.description ?? template.description,
   });
 
   if (error) {
@@ -456,12 +299,28 @@ export async function createCueSheetEventInstance(template: CueSheetEvent): Prom
   return event;
 }
 
-export async function createCueSheetChecklistInstance(template: Checklist): Promise<Checklist> {
+export async function createCueSheetBlankEvent(input: CreateBlankEventInput): Promise<CueSheetEvent> {
+  const now = new Date().toISOString();
+  const event: CueSheetEvent = {
+    id: crypto.randomUUID(),
+    kind: "instance",
+    title: input.title,
+    description: input.description,
+    duration: input.duration,
+    scheduledAt: input.scheduledAt,
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  return saveCueSheetEvent(event);
+}
+
+export async function createCueSheetChecklistInstance(template: Checklist, overrides: CreateChecklistInstanceOverrides = {}): Promise<Checklist> {
   const { data, error } = await supabase.rpc("create_checklist_from_template", {
     p_template_id: template.id,
-    p_scheduled_at: new Date().toISOString(),
-    p_name: `${template.name} Run`,
-    p_description: template.description,
+    p_scheduled_at: overrides.scheduledAt ?? new Date().toISOString(),
+    p_name: overrides.name ?? `${template.name} Run`,
+    p_description: overrides.description ?? template.description,
   });
 
   if (error) {
@@ -481,4 +340,21 @@ export async function createCueSheetChecklistInstance(template: Checklist): Prom
   }
 
   return checklist;
+}
+
+export async function createCueSheetBlankChecklist(input: CreateBlankChecklistInput): Promise<Checklist> {
+  const now = new Date().toISOString();
+  const checklist: Checklist = {
+    id: crypto.randomUUID(),
+    kind: "instance",
+    name: input.name,
+    description: input.description,
+    scheduledAt: input.scheduledAt,
+    items: [],
+    sections: [],
+    createdAt: now,
+    updatedAt: now,
+  };
+
+  return saveCueSheetChecklist(checklist);
 }

--- a/src/data/mutate-requests.ts
+++ b/src/data/mutate-requests.ts
@@ -57,14 +57,19 @@ export async function deleteRequest(id: string): Promise<void> {
 }
 
 export async function addRequestAssignee(requestId: string, userId: string, duty: string): Promise<void> {
-  const deleteResult = await supabase
+  const updateResult = await supabase
     .from("request_assignees")
-    .delete()
+    .update({ duty })
     .eq("request_id", requestId)
-    .eq("user_id", userId);
+    .eq("user_id", userId)
+    .select("id");
 
-  if (deleteResult.error) {
-    throw new Error(deleteResult.error.message);
+  if (updateResult.error) {
+    throw new Error(updateResult.error.message);
+  }
+
+  if ((updateResult.data ?? []).length > 0) {
+    return;
   }
 
   const { error } = await supabase

--- a/src/data/mutate-streams.ts
+++ b/src/data/mutate-streams.ts
@@ -33,6 +33,101 @@ type CreateStreamParams = {
   thumbnail: ThumbnailSource
 }
 
+type YouTubeBroadcastSyncRow = {
+  id: string
+  snippet: {
+    title: string
+    description?: string
+    thumbnails?: {
+      default?: {
+        url?: string
+      }
+    }
+    scheduledStartTime?: string | null
+    actualStartTime?: string | null
+    actualEndTime?: string | null
+  }
+  status: {
+    privacyStatus: string
+    madeForKids?: boolean
+    lifeCycleStatus: string
+  }
+  contentDetails?: {
+    boundStreamId?: string
+    enableDvr?: boolean
+    enableEmbed?: boolean
+    enableAutoStart?: boolean
+    enableAutoStop?: boolean
+    latencyPreference?: string
+  }
+}
+
+type LocalStreamInsertPayload = {
+  id?: string
+  workspace_id: string
+  youtube_broadcast_id: string
+  youtube_stream_id: string
+  title: string
+  description: string
+  thumbnail_url: string | null
+  privacy_status: string
+  is_for_kids: boolean
+  scheduled_start_time: string | null
+  actual_start_time?: string | null
+  actual_end_time?: string | null
+  stream_status: Stream["streamStatus"]
+  stream_url: string | null
+  stream_key?: string | null
+  ingestion_url?: string | null
+  category_id: string | null
+  tags: string[]
+  latency_preference: string
+  enable_dvr: boolean
+  enable_embed: boolean
+  enable_auto_start: boolean
+  enable_auto_stop: boolean
+  playlist_id: string | null
+  created_by: string
+}
+
+async function insertLocalStream(payload: LocalStreamInsertPayload): Promise<void> {
+  const { error } = await supabase.from("streams").insert(payload)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+}
+
+async function restoreLocalStream(stream: Stream): Promise<void> {
+  await insertLocalStream({
+    id: stream.id,
+    workspace_id: stream.workspaceId,
+    youtube_broadcast_id: stream.youtubeBroadcastId,
+    youtube_stream_id: stream.youtubeStreamId,
+    title: stream.title,
+    description: stream.description,
+    thumbnail_url: stream.thumbnailUrl,
+    privacy_status: stream.privacyStatus,
+    is_for_kids: stream.isForKids,
+    scheduled_start_time: stream.scheduledStartTime,
+    actual_start_time: stream.actualStartTime,
+    actual_end_time: stream.actualEndTime,
+    stream_status: stream.streamStatus,
+    stream_url: stream.streamUrl,
+    stream_key: stream.streamKey,
+    ingestion_url: stream.ingestionUrl,
+    category_id: stream.categoryId,
+    tags: stream.tags,
+    latency_preference: stream.latencyPreference,
+    enable_dvr: stream.enableDvr,
+    enable_embed: stream.enableEmbed,
+    enable_auto_start: stream.enableAutoStart,
+    enable_auto_stop: stream.enableAutoStop,
+    playlist_id: stream.playlistId,
+    created_by: stream.createdBy,
+  })
+}
+
 export async function createStream(params: CreateStreamParams): Promise<Stream> {
   const workspaceId = await getCurrentWorkspaceId()
   const { data: { user } } = await supabase.auth.getUser()
@@ -179,10 +274,20 @@ export async function createStream(params: CreateStreamParams): Promise<Stream> 
     created_by: user.id,
   }
 
-  const { error } = await supabase.from("streams").insert(payload)
+  try {
+    await insertLocalStream(payload)
+  } catch (error) {
+    const rollbackResponse = await youtubeApiFetch(
+      `/liveBroadcasts?id=${broadcast.id}`,
+      { method: "DELETE" },
+    )
 
-  if (error) {
-    throw new Error(error.message)
+    if (!rollbackResponse.ok) {
+      const rollbackError = await rollbackResponse.text()
+      throw new Error(`Local stream save failed after YouTube creation, and rollback also failed: ${rollbackError}`)
+    }
+
+    throw error
   }
 
   const saved = await fetchStreamById(payload.id)
@@ -299,18 +404,6 @@ export async function updateStream(
 }
 
 export async function deleteStream(stream: Stream): Promise<void> {
-  // Delete on YouTube
-  const response = await youtubeApiFetch(
-    `/liveBroadcasts?id=${stream.youtubeBroadcastId}`,
-    { method: "DELETE" },
-  )
-
-  if (!response.ok) {
-    const err = await response.text()
-    throw new Error(`Failed to delete broadcast: ${err}`)
-  }
-
-  // Delete locally
   const { error } = await supabase
     .from("streams")
     .delete()
@@ -318,6 +411,23 @@ export async function deleteStream(stream: Stream): Promise<void> {
 
   if (error) {
     throw new Error(error.message)
+  }
+
+  const response = await youtubeApiFetch(
+    `/liveBroadcasts?id=${stream.youtubeBroadcastId}`,
+    { method: "DELETE" },
+  )
+
+  if (!response.ok) {
+    try {
+      await restoreLocalStream(stream)
+    } catch (restoreError) {
+      const err = await response.text()
+      throw new Error(`Failed to delete broadcast and could not restore the local stream: ${err}; ${(restoreError as Error).message}`)
+    }
+
+    const err = await response.text()
+    throw new Error(`Failed to delete broadcast: ${err}`)
   }
 }
 
@@ -331,7 +441,7 @@ export async function syncStreamsFromYouTube(): Promise<Stream[]> {
 
   // Fetch only upcoming (scheduled) and active (live) broadcasts. Completed
   // broadcasts stay in our DB and are not re-fetched.
-  const broadcasts: any[] = []
+  const broadcasts: YouTubeBroadcastSyncRow[] = []
   for (const broadcastStatus of ["upcoming", "active"] as const) {
     let pageToken: string | undefined = undefined
     do {
@@ -345,7 +455,7 @@ export async function syncStreamsFromYouTube(): Promise<Stream[]> {
         throw new Error(`Failed to fetch broadcasts: ${err}`)
       }
 
-      const data = await response.json()
+      const data = await response.json() as { items?: YouTubeBroadcastSyncRow[]; nextPageToken?: string }
       broadcasts.push(...(data.items ?? []))
       pageToken = data.nextPageToken
     } while (pageToken)
@@ -393,9 +503,13 @@ export async function syncStreamsFromYouTube(): Promise<Stream[]> {
       created_by: user.id,
     }
 
-    await supabase
+    const { error } = await supabase
       .from("streams")
       .upsert(payload, { onConflict: "workspace_id,youtube_broadcast_id" })
+
+    if (error) {
+      throw new Error(error.message)
+    }
   }
 
   // Remove local non-complete streams that are no longer present remotely

--- a/src/data/mutate-zoom.ts
+++ b/src/data/mutate-zoom.ts
@@ -19,6 +19,71 @@ export type CreateMeetingParams = {
   continuousChat: boolean
 }
 
+type ZoomMeetingSyncRow = {
+  id: number
+  topic?: string
+  agenda?: string
+  type?: number
+  start_time?: string | null
+  duration?: number
+  timezone?: string
+  join_url?: string | null
+}
+
+type LocalZoomMeetingInsertPayload = {
+  id?: string
+  workspace_id: string
+  zoom_meeting_id: number
+  topic: string
+  description: string
+  meeting_type: ZoomMeeting["meetingType"]
+  start_time: string | null
+  duration: number
+  timezone: string
+  join_url: string | null
+  start_url?: string | null
+  password?: string | null
+  recurrence_type: ZoomRecurrenceType
+  recurrence_interval: number | null
+  recurrence_days: string | null
+  waiting_room: boolean
+  mute_on_entry: boolean
+  continuous_chat: boolean
+  created_by: string
+}
+
+async function insertLocalZoomMeeting(payload: LocalZoomMeetingInsertPayload): Promise<void> {
+  const { error } = await supabase.from("zoom_meetings").insert(payload)
+
+  if (error) {
+    throw new Error(error.message)
+  }
+}
+
+async function restoreLocalZoomMeeting(meeting: ZoomMeeting): Promise<void> {
+  await insertLocalZoomMeeting({
+    id: meeting.id,
+    workspace_id: meeting.workspaceId,
+    zoom_meeting_id: meeting.zoomMeetingId,
+    topic: meeting.topic,
+    description: meeting.description,
+    meeting_type: meeting.meetingType,
+    start_time: meeting.startTime,
+    duration: meeting.duration,
+    timezone: meeting.timezone,
+    join_url: meeting.joinUrl,
+    start_url: meeting.startUrl,
+    password: meeting.password,
+    recurrence_type: meeting.recurrenceType,
+    recurrence_interval: meeting.recurrenceInterval,
+    recurrence_days: meeting.recurrenceDays,
+    waiting_room: meeting.waitingRoom,
+    mute_on_entry: meeting.muteOnEntry,
+    continuous_chat: meeting.continuousChat,
+    created_by: meeting.createdBy,
+  })
+}
+
 function mapRecurrenceToZoomApi(params: CreateMeetingParams) {
   if (params.recurrenceType === "none") return undefined
 
@@ -97,7 +162,7 @@ export async function createZoomMeeting(params: CreateMeetingParams): Promise<Zo
   const meeting = await response.json()
 
   // Store in local database
-  const payload = {
+  const payload: LocalZoomMeetingInsertPayload = {
     id: crypto.randomUUID(),
     workspace_id: workspaceId,
     zoom_meeting_id: meeting.id,
@@ -118,14 +183,27 @@ export async function createZoomMeeting(params: CreateMeetingParams): Promise<Zo
     continuous_chat: params.continuousChat,
     created_by: user.id,
   }
+  const localMeetingId = payload.id
 
-  const { error } = await supabase.from("zoom_meetings").insert(payload)
+  try {
+    await insertLocalZoomMeeting(payload)
+  } catch (error) {
+    const rollbackResponse = await zoomApiFetch(`/meetings/${meeting.id}`, {
+      method: "DELETE",
+    })
 
-  if (error) {
-    throw new Error(error.message)
+    if (!rollbackResponse.ok && rollbackResponse.status !== 204) {
+      throw new Error(`Local meeting save failed after Zoom creation, and rollback also failed: ${await rollbackResponse.text()}`)
+    }
+
+    throw error
   }
 
-  const saved = await fetchZoomMeetingById(payload.id)
+  if (!localMeetingId) {
+    throw new Error("Created meeting payload is missing a local id")
+  }
+
+  const saved = await fetchZoomMeetingById(localMeetingId)
 
   if (!saved) {
     throw new Error("Created meeting could not be reloaded")
@@ -207,15 +285,6 @@ export async function updateZoomMeeting(meeting: ZoomMeeting): Promise<ZoomMeeti
 }
 
 export async function deleteZoomMeeting(meeting: ZoomMeeting): Promise<void> {
-  const response = await zoomApiFetch(`/meetings/${meeting.zoomMeetingId}`, {
-    method: "DELETE",
-  })
-
-  if (!response.ok && response.status !== 204) {
-    const err = await response.text()
-    throw new Error(`Failed to delete Zoom meeting: ${err}`)
-  }
-
   const { error } = await supabase
     .from("zoom_meetings")
     .delete()
@@ -223,6 +292,20 @@ export async function deleteZoomMeeting(meeting: ZoomMeeting): Promise<void> {
 
   if (error) {
     throw new Error(error.message)
+  }
+
+  const response = await zoomApiFetch(`/meetings/${meeting.zoomMeetingId}`, {
+    method: "DELETE",
+  })
+
+  if (!response.ok && response.status !== 204) {
+    try {
+      await restoreLocalZoomMeeting(meeting)
+    } catch (restoreError) {
+      throw new Error(`Failed to delete Zoom meeting and could not restore the local row: ${await response.text()}; ${(restoreError as Error).message}`)
+    }
+
+    throw new Error(`Failed to delete Zoom meeting: ${await response.text()}`)
   }
 }
 
@@ -246,9 +329,9 @@ export async function syncZoomMeetings(): Promise<ZoomMeeting[]> {
     throw new Error(`Failed to fetch Zoom meetings: ${await previousRes.text()}`)
   }
 
-  const upcomingData = await upcomingRes.json()
-  const previousData = await previousRes.json()
-  const byId = new Map<number, any>()
+  const upcomingData = await upcomingRes.json() as { meetings?: ZoomMeetingSyncRow[] }
+  const previousData = await previousRes.json() as { meetings?: ZoomMeetingSyncRow[] }
+  const byId = new Map<number, ZoomMeetingSyncRow>()
   for (const m of upcomingData.meetings ?? []) byId.set(m.id, m)
   for (const m of previousData.meetings ?? []) if (!byId.has(m.id)) byId.set(m.id, m)
   const meetings = Array.from(byId.values())
@@ -267,9 +350,13 @@ export async function syncZoomMeetings(): Promise<ZoomMeeting[]> {
       created_by: user.id,
     }
 
-    await supabase
+    const { error } = await supabase
       .from("zoom_meetings")
       .upsert(payload, { onConflict: "workspace_id,zoom_meeting_id" })
+
+    if (error) {
+      throw new Error(error.message)
+    }
   }
 
   const remoteIds = Array.from(byId.keys())

--- a/src/features/app-shell.tsx
+++ b/src/features/app-shell.tsx
@@ -62,7 +62,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                 <Sidebar.Panel>
                     <Sidebar.Header>
                         <div className="size-8 shrink-0 rounded-xl bg-brand_solid" >
-                            <img src="logo.svg" alt="" className='w-full h-full' />
+                            <img src="./logo.svg" alt="" className='w-full h-full' />
                         </div>
                         {!state.isCollapsed && (
                             <div className="flex flex-col">

--- a/src/features/cue-sheet/checklist-content.tsx
+++ b/src/features/cue-sheet/checklist-content.tsx
@@ -15,9 +15,10 @@ import { CSS } from '@dnd-kit/utilities'
 import { Accordion } from '@/components/display/accordion'
 import { Label, Paragraph } from '@/components/display/text'
 import type { Checklist, ChecklistItem, ChecklistSection } from '@/types/cue-sheet'
-import { Check, ChevronDown, GripVertical, Plus } from 'lucide-react'
+import { Check, ChevronDown, GripVertical, Plus, Trash2 } from 'lucide-react'
 import { cn } from '@/utils/cn'
 import { Input } from '@/components/form/input'
+import { InlineEditableText } from '@/components/form/inline-editable-text'
 
 // ─── Helpers ────────────────────────────────────────────────────────
 
@@ -177,7 +178,14 @@ function InlineSectionInput({ onSubmit, onDismiss }: { onSubmit: (value: string)
 
 // ─── Draggable check row ────────────────────────────────────────────
 
-function DraggableCheckRow({ item, onToggle }: { item: ChecklistItem; onToggle: (id: string) => void }) {
+type DraggableCheckRowProps = {
+    item: ChecklistItem
+    onToggle: (id: string) => void
+    onRename: (id: string, label: string) => void
+    onDelete: (id: string) => void
+}
+
+function DraggableCheckRow({ item, onToggle, onRename, onDelete }: DraggableCheckRowProps) {
     const { attributes, listeners, setNodeRef: setDragRef, transform, isDragging } = useDraggable({ id: `item:${item.id}` })
     const { setNodeRef: setDropRef } = useDroppable({ id: `item:${item.id}` })
 
@@ -192,22 +200,33 @@ function DraggableCheckRow({ item, onToggle }: { item: ChecklistItem; onToggle: 
                 <span {...listeners} {...attributes} className="cursor-grab text-quaternary hover:text-secondary shrink-0 opacity-0 group-hover/item:opacity-100 transition-opacity">
                     <GripVertical className="size-4" />
                 </span>
+                <div className="flex flex-1 items-center gap-3 min-w-0">
+                    <button
+                        type="button"
+                        className="flex items-center gap-3 text-left"
+                        onClick={() => onToggle(item.id)}
+                    >
+                        <div
+                            className={cn(
+                                'size-5 shrink-0 rounded border flex items-center justify-center transition-colors',
+                                item.checked ? 'bg-brand_solid border-transparent' : 'border-secondary bg-primary',
+                            )}
+                        >
+                            {item.checked && <Check className="size-3.5 text-white" />}
+                        </div>
+                    </button>
+                    <InlineEditableText
+                        value={item.label}
+                        onSave={(label) => onRename(item.id, label)}
+                        className={cn('label-sm min-w-0 flex-1', item.checked && 'line-through text-tertiary')}
+                    />
+                </div>
                 <button
                     type="button"
-                    className="flex items-center gap-3 flex-1 text-left"
-                    onClick={() => onToggle(item.id)}
+                    className="shrink-0 rounded p-1 text-quaternary opacity-0 transition-opacity hover:bg-background-primary-hover hover:text-secondary group-hover/item:opacity-100"
+                    onClick={() => onDelete(item.id)}
                 >
-                    <div
-                        className={cn(
-                            'size-5 shrink-0 rounded border flex items-center justify-center transition-colors',
-                            item.checked ? 'bg-brand_solid border-transparent' : 'border-secondary bg-primary',
-                        )}
-                    >
-                        {item.checked && <Check className="size-3.5 text-white" />}
-                    </div>
-                    <Label.sm className={cn(item.checked && 'line-through text-tertiary')}>
-                        {item.label}
-                    </Label.sm>
+                    <Trash2 className="size-4" />
                 </button>
             </div>
         </div>
@@ -283,6 +302,10 @@ type SectionRowProps = {
     section: ChecklistSection
     onToggle: (id: string) => void
     onAddItem: (sectionId: string, label: string) => void
+    onRenameItem: (id: string, label: string) => void
+    onDeleteItem: (id: string) => void
+    onRenameSection: (sectionId: string, name: string) => void
+    onDeleteSection: (sectionId: string) => void
     activeItemId: string | null
     overItemId: string | null
     isAddingItem: boolean
@@ -290,7 +313,7 @@ type SectionRowProps = {
     onDismissAdd: () => void
 }
 
-function SectionRow({ section, onToggle, onAddItem, activeItemId, overItemId, isAddingItem, onRequestAddItem, onDismissAdd }: SectionRowProps) {
+function SectionRow({ section, onToggle, onAddItem, onRenameItem, onDeleteItem, onRenameSection, onDeleteSection, activeItemId, overItemId, isAddingItem, onRequestAddItem, onDismissAdd }: SectionRowProps) {
     const { setNodeRef: setSectionDropRef } = useDroppable({ id: `section:${section.id}` })
     const checkedCount = section.items.filter((i) => i.checked).length
 
@@ -307,7 +330,7 @@ function SectionRow({ section, onToggle, onAddItem, activeItemId, overItemId, is
                     </div>
                     <Accordion.Trigger className="flex items-center gap-3 px-2 pl-1.5 py-2.5 hover:bg-background-primary-hover transition-colors">
                         <ChevronDown className="size-4 shrink-0 text-tertiary transition-transform data-[state=open]:rotate-180" />
-                        <Label.sm className="text-left">{section.name}</Label.sm>
+                        <InlineEditableText value={section.name} onSave={(name) => onRenameSection(section.id, name)} className="label-sm text-left" />
                         <Paragraph.xs className="text-tertiary shrink-0">{checkedCount}/{section.items.length}</Paragraph.xs>
                     </Accordion.Trigger>
                     <button
@@ -316,6 +339,13 @@ function SectionRow({ section, onToggle, onAddItem, activeItemId, overItemId, is
                         onClick={(e) => { e.stopPropagation(); onRequestAddItem(section.id) }}
                     >
                         <Plus className="size-4" />
+                    </button>
+                    <button
+                        type="button"
+                        className="shrink-0 mr-2 p-1 rounded text-quaternary hover:text-secondary hover:bg-background-primary-hover transition-colors"
+                        onClick={(e) => { e.stopPropagation(); onDeleteSection(section.id) }}
+                    >
+                        <Trash2 className="size-4" />
                     </button>
                 </div>
 
@@ -330,7 +360,7 @@ function SectionRow({ section, onToggle, onAddItem, activeItemId, overItemId, is
                             return (
                                 <div key={item.id} className="relative">
                                     {showAbove && <DropIndicatorLine />}
-                                    <DraggableCheckRow item={item} onToggle={onToggle} />
+                                    <DraggableCheckRow item={item} onToggle={onToggle} onRename={onRenameItem} onDelete={onDeleteItem} />
                                     {showBelow && <DropIndicatorLine />}
                                 </div>
                             )
@@ -415,6 +445,47 @@ export function ChecklistContent({ checklist, onUpdate, addRequest = null, onAdd
     function handleAddSection(name: string) {
         const newSection: ChecklistSection = { id: crypto.randomUUID(), name, items: [] }
         onUpdate({ ...checklist, sections: [...checklist.sections, newSection] })
+    }
+
+    function handleRenameItem(itemId: string, label: string) {
+        const topItem = checklist.items.find((item) => item.id === itemId)
+        if (topItem) {
+            onUpdate({
+                ...checklist,
+                items: checklist.items.map((item) => item.id === itemId ? { ...item, label } : item),
+            })
+            return
+        }
+
+        onUpdate({
+            ...checklist,
+            sections: checklist.sections.map((section) => ({
+                ...section,
+                items: section.items.map((item) => item.id === itemId ? { ...item, label } : item),
+            })),
+        })
+    }
+
+    function handleDeleteItem(itemId: string) {
+        onUpdate(removeItemFrom(checklist, itemId))
+    }
+
+    function handleRenameSection(sectionId: string, name: string) {
+        onUpdate({
+            ...checklist,
+            sections: checklist.sections.map((section) => section.id === sectionId ? { ...section, name } : section),
+        })
+    }
+
+    function handleDeleteSection(sectionId: string) {
+        const section = checklist.sections.find((entry) => entry.id === sectionId)
+        if (!section) return
+
+        onUpdate({
+            ...checklist,
+            items: [...checklist.items, ...section.items],
+            sections: checklist.sections.filter((entry) => entry.id !== sectionId),
+        })
     }
 
     // ── Section + button triggers add ───────────────────────
@@ -546,7 +617,7 @@ export function ChecklistContent({ checklist, onUpdate, addRequest = null, onAdd
                         return (
                             <div key={item.id} className="relative">
                                 {showAbove && <DropIndicatorLine />}
-                                <DraggableCheckRow item={item} onToggle={handleToggle} />
+                                <DraggableCheckRow item={item} onToggle={handleToggle} onRename={handleRenameItem} onDelete={handleDeleteItem} />
                                 {showBelow && <DropIndicatorLine />}
                             </div>
                         )
@@ -568,6 +639,10 @@ export function ChecklistContent({ checklist, onUpdate, addRequest = null, onAdd
                                 section={section}
                                 onToggle={handleToggle}
                                 onAddItem={handleAddSectionItem}
+                                onRenameItem={handleRenameItem}
+                                onDeleteItem={handleDeleteItem}
+                                onRenameSection={handleRenameSection}
+                                onDeleteSection={handleDeleteSection}
                                 activeItemId={activeId}
                                 overItemId={overId}
                                 isAddingItem={currentAdd?.type === 'item' && currentAdd.target === section.id}

--- a/src/features/cue-sheet/checklist-drawer.tsx
+++ b/src/features/cue-sheet/checklist-drawer.tsx
@@ -1,13 +1,16 @@
 import { Drawer, useDrawer } from '@/components/overlays/drawer'
+import { Modal } from '@/components/overlays/modal'
 import { Button } from '@/components/controls/button'
 import { Divider } from '@/components/display/divider'
 import { Dropdown } from '@/components/overlays/dropdown'
-import { Paragraph, Title } from '@/components/display/text'
+import { Label, Paragraph, Title } from '@/components/display/text'
+import { InlineEditableText } from '@/components/form/inline-editable-text'
+import { useFeedback } from '@/components/feedback/feedback-provider'
 import type { Checklist } from '@/types/cue-sheet'
 import { useCueSheet } from './cue-sheet-provider'
 import { ChecklistContent, getChecklistCounts, type AddRequest } from './checklist-content'
-import { FolderPlus, Maximize2, Plus, SquarePlus, X } from 'lucide-react'
-import { useState } from 'react'
+import { FolderPlus, Maximize2, Plus, SquarePlus, Trash2, TriangleAlert, X } from 'lucide-react'
+import { useCallback, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 export function ChecklistDrawer({ checklist }: { checklist: Checklist }) {
@@ -23,15 +26,36 @@ export function ChecklistDrawer({ checklist }: { checklist: Checklist }) {
 
 function ChecklistDrawerContent({ checklist }: { checklist: Checklist }) {
     const { actions: drawerActions } = useDrawer()
-    const { actions: { syncChecklist } } = useCueSheet()
+    const { actions: { syncChecklist, removeChecklist } } = useCueSheet()
+    const { toast } = useFeedback()
     const navigate = useNavigate()
     const [addRequest, setAddRequest] = useState<AddRequest>(null)
+    const [deleteOpen, setDeleteOpen] = useState(false)
 
     const { total, checked } = getChecklistCounts(checklist)
 
     function handleOpenFullPage() {
         drawerActions.close()
         navigate(`/cue-sheet/checklist/${checklist.id}`)
+    }
+
+    const handleChecklistUpdate = useCallback(async (nextChecklist: Checklist) => {
+        try {
+            await syncChecklist(nextChecklist)
+        } catch (error) {
+            toast({ title: 'Failed to save checklist', description: error instanceof Error ? error.message : 'The checklist could not be saved.', variant: 'error' })
+        }
+    }, [syncChecklist, toast])
+
+    async function handleDelete() {
+        try {
+            await removeChecklist(checklist.id)
+            toast({ title: 'Checklist deleted', variant: 'success' })
+            setDeleteOpen(false)
+            drawerActions.close()
+        } catch (error) {
+            toast({ title: 'Failed to delete checklist', description: error instanceof Error ? error.message : 'The checklist could not be deleted.', variant: 'error' })
+        }
     }
 
     return (
@@ -41,14 +65,18 @@ function ChecklistDrawerContent({ checklist }: { checklist: Checklist }) {
                 <Button.Icon variant="ghost" icon={<Maximize2 />} onClick={handleOpenFullPage} />
                 <div className="flex-1" />
                 <Paragraph.sm className="text-tertiary mr-2">{checked}/{total} done</Paragraph.sm>
-
+                <Button.Icon variant="danger-secondary" icon={<Trash2 />} onClick={() => setDeleteOpen(true)} />
             </Drawer.Header>
 
             <Drawer.Content className="py-4">
                 <div className="px-4 pb-2 flex tems-start gap-2">
                     <div className="mr-auto">
-                        <Title.h6>{checklist.name}</Title.h6>
-                        <Paragraph.sm className="text-tertiary pt-1">{checklist.description}</Paragraph.sm>
+                        <Title.h6>
+                            <InlineEditableText value={checklist.name} onSave={(name) => { void handleChecklistUpdate({ ...checklist, name }) }} className="title-h6" />
+                        </Title.h6>
+                        <Paragraph.sm className="text-tertiary pt-1">
+                            <InlineEditableText value={checklist.description} onSave={(description) => { void handleChecklistUpdate({ ...checklist, description }) }} className="text-sm text-tertiary" placeholder="Add description" />
+                        </Paragraph.sm>
                     </div>
                     <Dropdown.Root placement="bottom">
                         <Dropdown.Trigger>
@@ -71,11 +99,34 @@ function ChecklistDrawerContent({ checklist }: { checklist: Checklist }) {
 
                 <ChecklistContent
                     checklist={checklist}
-                    onUpdate={syncChecklist}
+                    onUpdate={(nextChecklist) => { void handleChecklistUpdate(nextChecklist) }}
                     addRequest={addRequest}
                     onAddRequestDismiss={() => setAddRequest(null)}
                 />
             </Drawer.Content>
+
+            <Modal.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <Modal.Portal>
+                    <Modal.Backdrop />
+                    <Modal.Positioner>
+                        <Modal.Panel>
+                            <Modal.Header>
+                                <Label.md>Delete Checklist</Label.md>
+                            </Modal.Header>
+                            <Modal.Content className="p-4 flex-row gap-4">
+                                <TriangleAlert className="size-8 shrink-0 text-utility-red-600" />
+                                <Paragraph.sm className="text-secondary">
+                                    Are you sure you want to delete this checklist? This action cannot be undone.
+                                </Paragraph.sm>
+                            </Modal.Content>
+                            <Modal.Footer className="justify-end">
+                                <Button variant="secondary" onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                                <Button variant="danger" onClick={handleDelete}>Delete Checklist</Button>
+                            </Modal.Footer>
+                        </Modal.Panel>
+                    </Modal.Positioner>
+                </Modal.Portal>
+            </Modal.Root>
         </>
     )
 }

--- a/src/features/cue-sheet/create-checklist-run-modal.tsx
+++ b/src/features/cue-sheet/create-checklist-run-modal.tsx
@@ -1,0 +1,90 @@
+import { Modal } from '@/components/overlays/modal'
+import { Button } from '@/components/controls/button'
+import { Input } from '@/components/form/input'
+import { FormLabel } from '@/components/form/form-label'
+import { Label } from '@/components/display/text'
+import type { Checklist } from '@/types/cue-sheet'
+import { formatUtcIsoForBrowserDateTimeInput, parseBrowserDateTimeInputToUtcIso } from '@/utils/browser-date-time'
+import { useCallback, useEffect, useState } from 'react'
+
+export type ChecklistRunSubmit =
+    | { kind: 'template'; template: Checklist; name: string; description: string; scheduledAt: string }
+    | { kind: 'blank'; name: string; description: string; scheduledAt: string }
+
+type Props = {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    template: Checklist | null
+    onSubmit: (input: ChecklistRunSubmit) => Promise<void> | void
+}
+
+export function CreateChecklistRunModal({ open, onOpenChange, template, onSubmit }: Props) {
+    const [name, setName] = useState('')
+    const [description, setDescription] = useState('')
+    const [scheduledAt, setScheduledAt] = useState(formatUtcIsoForBrowserDateTimeInput(new Date().toISOString()))
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    useEffect(() => {
+        if (!open) return
+        setName(template ? `${template.name} Run` : '')
+        setDescription(template ? template.description : '')
+        setScheduledAt(formatUtcIsoForBrowserDateTimeInput(new Date().toISOString()))
+    }, [open, template])
+
+    const canSubmit = name.trim().length > 0 && scheduledAt.length > 0 && !isSubmitting
+
+    const handleSubmit = useCallback(async () => {
+        if (!canSubmit) return
+        setIsSubmitting(true)
+        try {
+            const scheduledIso = parseBrowserDateTimeInputToUtcIso(scheduledAt)
+            if (template) {
+                await onSubmit({ kind: 'template', template, name: name.trim(), description: description.trim(), scheduledAt: scheduledIso })
+            } else {
+                await onSubmit({ kind: 'blank', name: name.trim(), description: description.trim(), scheduledAt: scheduledIso })
+            }
+            onOpenChange(false)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }, [canSubmit, description, name, onOpenChange, onSubmit, scheduledAt, template])
+
+    return (
+        <Modal.Root open={open} onOpenChange={onOpenChange}>
+            <Modal.Portal>
+                <Modal.Backdrop />
+                <Modal.Positioner>
+                    <Modal.Panel className="max-w-md">
+                        <Modal.Header>
+                            <Label.md>{template ? `New Run from "${template.name}"` : 'New Blank Checklist Run'}</Label.md>
+                        </Modal.Header>
+                        <Modal.Content>
+                            <div className="flex flex-col gap-4 p-4">
+                                <div className="flex flex-col gap-1.5">
+                                    <FormLabel label="Name" required />
+                                    <Input placeholder="Checklist name" value={name} onChange={(e) => setName(e.target.value)} />
+                                </div>
+                                <div className="flex flex-col gap-1.5">
+                                    <FormLabel label="Description" optional />
+                                    <Input placeholder="Brief description" value={description} onChange={(e) => setDescription(e.target.value)} />
+                                </div>
+                                <div className="flex flex-col gap-1.5">
+                                    <FormLabel label="Scheduled" required />
+                                    <Input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} />
+                                </div>
+                            </div>
+                        </Modal.Content>
+                        <Modal.Footer>
+                            <Modal.Close>
+                                <Button variant="secondary">Cancel</Button>
+                            </Modal.Close>
+                            <Button onClick={handleSubmit} disabled={!canSubmit}>
+                                {isSubmitting ? 'Creating...' : 'Create'}
+                            </Button>
+                        </Modal.Footer>
+                    </Modal.Panel>
+                </Modal.Positioner>
+            </Modal.Portal>
+        </Modal.Root>
+    )
+}

--- a/src/features/cue-sheet/create-event-run-modal.tsx
+++ b/src/features/cue-sheet/create-event-run-modal.tsx
@@ -1,0 +1,98 @@
+import { Modal } from '@/components/overlays/modal'
+import { Button } from '@/components/controls/button'
+import { Input } from '@/components/form/input'
+import { FormLabel } from '@/components/form/form-label'
+import { Label } from '@/components/display/text'
+import type { CueSheetEvent } from '@/types/cue-sheet'
+import { formatUtcIsoForBrowserDateTimeInput, parseBrowserDateTimeInputToUtcIso } from '@/utils/browser-date-time'
+import { useCallback, useEffect, useState } from 'react'
+
+export type EventRunSubmit =
+    | { kind: 'template'; template: CueSheetEvent; title: string; description: string; scheduledAt: string }
+    | { kind: 'blank'; title: string; description: string; scheduledAt: string; duration: number }
+
+type Props = {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    template: CueSheetEvent | null
+    onSubmit: (input: EventRunSubmit) => Promise<void> | void
+}
+
+export function CreateEventRunModal({ open, onOpenChange, template, onSubmit }: Props) {
+    const [title, setTitle] = useState('')
+    const [description, setDescription] = useState('')
+    const [scheduledAt, setScheduledAt] = useState(formatUtcIsoForBrowserDateTimeInput(new Date().toISOString()))
+    const [duration, setDuration] = useState(60)
+    const [isSubmitting, setIsSubmitting] = useState(false)
+
+    useEffect(() => {
+        if (!open) return
+        setTitle(template ? `${template.title} Run` : '')
+        setDescription(template ? template.description : '')
+        setScheduledAt(formatUtcIsoForBrowserDateTimeInput(new Date().toISOString()))
+        setDuration(template ? template.duration : 60)
+    }, [open, template])
+
+    const canSubmit = title.trim().length > 0 && scheduledAt.length > 0 && (template !== null || duration > 0) && !isSubmitting
+
+    const handleSubmit = useCallback(async () => {
+        if (!canSubmit) return
+        setIsSubmitting(true)
+        try {
+            const scheduledIso = parseBrowserDateTimeInputToUtcIso(scheduledAt)
+            if (template) {
+                await onSubmit({ kind: 'template', template, title: title.trim(), description: description.trim(), scheduledAt: scheduledIso })
+            } else {
+                await onSubmit({ kind: 'blank', title: title.trim(), description: description.trim(), scheduledAt: scheduledIso, duration })
+            }
+            onOpenChange(false)
+        } finally {
+            setIsSubmitting(false)
+        }
+    }, [canSubmit, description, duration, onOpenChange, onSubmit, scheduledAt, template, title])
+
+    return (
+        <Modal.Root open={open} onOpenChange={onOpenChange}>
+            <Modal.Portal>
+                <Modal.Backdrop />
+                <Modal.Positioner>
+                    <Modal.Panel className="max-w-md">
+                        <Modal.Header>
+                            <Label.md>{template ? `New Run from "${template.title}"` : 'New Blank Event Run'}</Label.md>
+                        </Modal.Header>
+                        <Modal.Content>
+                            <div className="flex flex-col gap-4 p-4">
+                                <div className="flex flex-col gap-1.5">
+                                    <FormLabel label="Title" required />
+                                    <Input placeholder="Event title" value={title} onChange={(e) => setTitle(e.target.value)} />
+                                </div>
+                                <div className="flex flex-col gap-1.5">
+                                    <FormLabel label="Description" optional />
+                                    <Input placeholder="Brief description" value={description} onChange={(e) => setDescription(e.target.value)} />
+                                </div>
+                                <div className="flex flex-col gap-1.5">
+                                    <FormLabel label="Scheduled" required />
+                                    <Input type="datetime-local" value={scheduledAt} onChange={(e) => setScheduledAt(e.target.value)} />
+                                </div>
+                                {!template && (
+                                    <div className="flex flex-col gap-1.5">
+                                        <FormLabel label="Duration (minutes)" required />
+                                        <Input type="number" value={String(duration)} onChange={(e) => setDuration(Number(e.target.value) || 0)} />
+                                    </div>
+                                )}
+                            </div>
+                        </Modal.Content>
+                        <Modal.Footer>
+                            <Modal.Close>
+                                <Button variant="secondary">Cancel</Button>
+                            </Modal.Close>
+                            <Button onClick={handleSubmit} disabled={!canSubmit}>
+                                {isSubmitting ? 'Creating...' : 'Create'}
+                            </Button>
+                        </Modal.Footer>
+                    </Modal.Panel>
+                </Modal.Positioner>
+            </Modal.Portal>
+        </Modal.Root>
+    )
+}

--- a/src/features/cue-sheet/cue-sheet-provider.tsx
+++ b/src/features/cue-sheet/cue-sheet-provider.tsx
@@ -7,6 +7,8 @@ import {
     fetchCueSheetTracksByEventId,
 } from '@/data/fetch-cue-sheet'
 import {
+    createCueSheetBlankChecklist,
+    createCueSheetBlankEvent,
     createCueSheetChecklistInstance,
     createCueSheetEventInstance,
     deleteCueSheetChecklist,
@@ -14,6 +16,10 @@ import {
     saveCueSheetChecklist,
     saveCueSheetEvent,
     saveCueSheetTracks,
+    type CreateBlankChecklistInput,
+    type CreateBlankEventInput,
+    type CreateChecklistInstanceOverrides,
+    type CreateEventInstanceOverrides,
 } from '@/data/mutate-cue-sheet'
 import { createContext, useCallback, useContext, useMemo, useRef, useState, type ReactNode } from 'react'
 
@@ -35,8 +41,10 @@ type CueSheetContextValue = {
         syncChecklist: (checklist: Checklist) => Promise<void>
         syncEvent: (event: CueSheetEvent) => Promise<void>
         syncTracks: (eventId: string, tracks: Track[]) => Promise<void>
-        createEventInstance: (template: CueSheetEvent) => Promise<CueSheetEvent>
-        createChecklistInstance: (template: Checklist) => Promise<Checklist>
+        createEventInstance: (template: CueSheetEvent, overrides?: CreateEventInstanceOverrides) => Promise<CueSheetEvent>
+        createBlankEvent: (input: CreateBlankEventInput) => Promise<CueSheetEvent>
+        createChecklistInstance: (template: Checklist, overrides?: CreateChecklistInstanceOverrides) => Promise<Checklist>
+        createBlankChecklist: (input: CreateBlankChecklistInput) => Promise<Checklist>
         removeEvent: (id: string) => Promise<void>
         removeChecklist: (id: string) => Promise<void>
     }
@@ -107,13 +115,26 @@ export function CueSheetProvider({ children }: { children: ReactNode }) {
     }, [eventsById, tracksByEventId])
 
     const syncChecklist = useCallback(async (checklist: Checklist) => {
-        const savedChecklist = await saveCueSheetChecklist(checklist)
+        const previousChecklists = checklists
+
         setChecklists((prev) => {
-            const idx = prev.findIndex((c) => c.id === savedChecklist.id)
-            if (idx === -1) return [...prev, savedChecklist]
-            return prev.map((c) => (c.id === savedChecklist.id ? savedChecklist : c))
+            const idx = prev.findIndex((c) => c.id === checklist.id)
+            if (idx === -1) return [...prev, checklist]
+            return prev.map((c) => (c.id === checklist.id ? checklist : c))
         })
-    }, [])
+
+        try {
+            const savedChecklist = await saveCueSheetChecklist(checklist)
+            setChecklists((prev) => {
+                const idx = prev.findIndex((c) => c.id === savedChecklist.id)
+                if (idx === -1) return [...prev, savedChecklist]
+                return prev.map((c) => (c.id === savedChecklist.id ? savedChecklist : c))
+            })
+        } catch (error) {
+            setChecklists(previousChecklists)
+            throw error
+        }
+    }, [checklists])
 
     const syncEvent = useCallback(async (event: CueSheetEvent) => {
         const savedEvent = await saveCueSheetEvent(event)
@@ -131,16 +152,29 @@ export function CueSheetProvider({ children }: { children: ReactNode }) {
         setTracksByEventId((prev) => ({ ...prev, [eventId]: savedTracks }))
     }, [eventsById])
 
-    const createEventInstance = useCallback(async (template: CueSheetEvent) => {
-        const savedEvent = await createCueSheetEventInstance(template)
+    const createEventInstance = useCallback(async (template: CueSheetEvent, overrides?: CreateEventInstanceOverrides) => {
+        const savedEvent = await createCueSheetEventInstance(template, overrides)
         const savedTracks = await fetchCueSheetTracksByEventId(savedEvent.id)
         setEventsById((prev) => ({ ...prev, [savedEvent.id]: savedEvent }))
         setTracksByEventId((prev) => ({ ...prev, [savedEvent.id]: savedTracks }))
         return savedEvent
     }, [])
 
-    const createChecklistInstance = useCallback(async (template: Checklist) => {
-        const savedChecklist = await createCueSheetChecklistInstance(template)
+    const createBlankEvent = useCallback(async (input: CreateBlankEventInput) => {
+        const savedEvent = await createCueSheetBlankEvent(input)
+        setEventsById((prev) => ({ ...prev, [savedEvent.id]: savedEvent }))
+        setTracksByEventId((prev) => ({ ...prev, [savedEvent.id]: [] }))
+        return savedEvent
+    }, [])
+
+    const createChecklistInstance = useCallback(async (template: Checklist, overrides?: CreateChecklistInstanceOverrides) => {
+        const savedChecklist = await createCueSheetChecklistInstance(template, overrides)
+        setChecklists((prev) => [...prev, savedChecklist])
+        return savedChecklist
+    }, [])
+
+    const createBlankChecklist = useCallback(async (input: CreateBlankChecklistInput) => {
+        const savedChecklist = await createCueSheetBlankChecklist(input)
         setChecklists((prev) => [...prev, savedChecklist])
         return savedChecklist
     }, [])
@@ -183,11 +217,13 @@ export function CueSheetProvider({ children }: { children: ReactNode }) {
             syncEvent,
             syncTracks,
             createEventInstance,
+            createBlankEvent,
             createChecklistInstance,
+            createBlankChecklist,
             removeEvent,
             removeChecklist,
         },
-    }), [events, checklists, eventsById, tracksByEventId, isLoadingEvents, isLoadingChecklists, loadEvents, loadChecklists, loadEvent, syncChecklist, syncEvent, syncTracks, createEventInstance, createChecklistInstance, removeEvent, removeChecklist])
+    }), [events, checklists, eventsById, tracksByEventId, isLoadingEvents, isLoadingChecklists, loadEvents, loadChecklists, loadEvent, syncChecklist, syncEvent, syncTracks, createEventInstance, createBlankEvent, createChecklistInstance, createBlankChecklist, removeEvent, removeChecklist])
 
     return <CueSheetContext.Provider value={value}>{children}</CueSheetContext.Provider>
 }

--- a/src/features/cue-sheet/event-drawer.tsx
+++ b/src/features/cue-sheet/event-drawer.tsx
@@ -1,0 +1,154 @@
+import { Drawer, useDrawer } from '@/components/overlays/drawer'
+import { Modal } from '@/components/overlays/modal'
+import { Button } from '@/components/controls/button'
+import { Badge } from '@/components/display/badge'
+import { Divider } from '@/components/display/divider'
+import { Label, Paragraph, Title } from '@/components/display/text'
+import { InlineEditableText } from '@/components/form/inline-editable-text'
+import { useFeedback } from '@/components/feedback/feedback-provider'
+import { CalendarClock, Clock, Layers, Maximize2, Trash2, TriangleAlert, X } from 'lucide-react'
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import type { CueSheetEvent } from '@/types/cue-sheet'
+import { useCueSheet } from './cue-sheet-provider'
+import { formatUtcIsoInBrowserTimeZone } from '@/utils/browser-date-time'
+
+function formatDuration(minutes: number) {
+    const h = Math.floor(minutes / 60)
+    const m = minutes % 60
+    if (h === 0) return `${m}min`
+    if (m === 0) return `${h}h`
+    return `${h}h ${m}min`
+}
+
+function formatScheduledAt(scheduledAt?: string) {
+    if (!scheduledAt) return null
+    return formatUtcIsoInBrowserTimeZone(scheduledAt, { dateStyle: 'medium', timeStyle: 'short' })
+}
+
+export function EventDrawer({ event }: { event: CueSheetEvent }) {
+    return (
+        <Drawer.Portal>
+            <Drawer.Backdrop />
+            <Drawer.Panel className="!max-w-lg">
+                <EventDrawerContent event={event} />
+            </Drawer.Panel>
+        </Drawer.Portal>
+    )
+}
+
+function EventDrawerContent({ event }: { event: CueSheetEvent }) {
+    const { actions: drawerActions } = useDrawer()
+    const { state: { tracksByEventId }, actions: { syncEvent, removeEvent } } = useCueSheet()
+    const { toast } = useFeedback()
+    const navigate = useNavigate()
+    const [deleteOpen, setDeleteOpen] = useState(false)
+
+    const trackCount = tracksByEventId[event.id]?.length ?? 0
+    const scheduledAt = formatScheduledAt(event.scheduledAt)
+
+    function handleOpenFullPage() {
+        drawerActions.close()
+        navigate(`/cue-sheet/events/${event.id}`)
+    }
+
+    async function handleDelete() {
+        try {
+            await removeEvent(event.id)
+            toast({ title: 'Event deleted', variant: 'success' })
+            setDeleteOpen(false)
+            drawerActions.close()
+        } catch (error) {
+            toast({ title: 'Failed to delete event', description: error instanceof Error ? error.message : 'The event could not be deleted.', variant: 'error' })
+        }
+    }
+
+    return (
+        <>
+            <Drawer.Header className="flex items-center gap-1">
+                <Button.Icon variant="ghost" icon={<X />} onClick={drawerActions.close} />
+                <Button.Icon variant="ghost" icon={<Maximize2 />} onClick={handleOpenFullPage} />
+                <div className="flex-1" />
+                <Button.Icon variant="danger-secondary" icon={<Trash2 />} onClick={() => setDeleteOpen(true)} />
+            </Drawer.Header>
+
+            <Drawer.Content className="py-4">
+                <div className="px-4 pb-2">
+                    <Title.h6>
+                        <InlineEditableText
+                            value={event.title}
+                            onSave={(title) => syncEvent({ ...event, title })}
+                            className="title-h6"
+                        />
+                    </Title.h6>
+                    <Paragraph.sm className="text-tertiary pt-1">
+                        <InlineEditableText
+                            value={event.description}
+                            onSave={(description) => syncEvent({ ...event, description })}
+                            className="text-sm text-tertiary"
+                            placeholder="Add description"
+                        />
+                    </Paragraph.sm>
+                </div>
+
+                <Divider className="px-4 py-3" />
+
+                <div className="flex flex-col gap-3 px-4">
+                    <div className="flex items-center justify-between gap-4">
+                        <Label.sm className="text-tertiary">Scheduled</Label.sm>
+                        {scheduledAt
+                            ? <Badge label={scheduledAt} icon={<CalendarClock />} color="purple" />
+                            : <Paragraph.sm className="text-tertiary">Not scheduled</Paragraph.sm>
+                        }
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                        <Label.sm className="text-tertiary">Duration</Label.sm>
+                        <Badge label={formatDuration(event.duration)} icon={<Clock />} variant="outline" />
+                    </div>
+                    <div className="flex items-center justify-between gap-4">
+                        <Label.sm className="text-tertiary">Tracks</Label.sm>
+                        <Badge
+                            label={`${trackCount} track${trackCount !== 1 ? 's' : ''}`}
+                            icon={<Layers />}
+                            color={trackCount > 0 ? 'blue' : 'gray'}
+                        />
+                    </div>
+                    {event.kind === 'instance' && event.templateId && (
+                        <div className="flex items-center justify-between gap-4">
+                            <Label.sm className="text-tertiary">Kind</Label.sm>
+                            <Paragraph.sm className="text-secondary">Run from template</Paragraph.sm>
+                        </div>
+                    )}
+                </div>
+            </Drawer.Content>
+
+            <Drawer.Footer className="justify-end">
+                <Button variant="secondary" onClick={drawerActions.close}>Close</Button>
+                <Button icon={<Maximize2 />} onClick={handleOpenFullPage}>Open timeline</Button>
+            </Drawer.Footer>
+
+            <Modal.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <Modal.Portal>
+                    <Modal.Backdrop />
+                    <Modal.Positioner>
+                        <Modal.Panel>
+                            <Modal.Header>
+                                <Label.md>Delete Event</Label.md>
+                            </Modal.Header>
+                            <Modal.Content className="p-4 flex-row gap-4">
+                                <TriangleAlert className="size-8 shrink-0 text-utility-red-600" />
+                                <Paragraph.sm className="text-secondary">
+                                    Are you sure you want to delete this event? This action cannot be undone.
+                                </Paragraph.sm>
+                            </Modal.Content>
+                            <Modal.Footer className="justify-end">
+                                <Button variant="secondary" onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                                <Button variant="danger" onClick={handleDelete}>Delete Event</Button>
+                            </Modal.Footer>
+                        </Modal.Panel>
+                    </Modal.Positioner>
+                </Modal.Portal>
+            </Modal.Root>
+        </>
+    )
+}

--- a/src/features/cue-sheet/event-item.tsx
+++ b/src/features/cue-sheet/event-item.tsx
@@ -1,11 +1,13 @@
 import { Label, Paragraph } from '@/components/display/text'
 import { Badge } from '@/components/display/badge'
+import { Drawer } from '@/components/overlays/drawer'
 import { cn } from '@/utils/cn'
 import { cv } from '@/utils/cv'
 import type { CueSheetEvent } from '@/types/cue-sheet'
 import { CalendarClock, Clock, Layers } from 'lucide-react'
-import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
 import { useCueSheet } from './cue-sheet-provider'
+import { EventDrawer } from './event-drawer'
 import { formatUtcIsoInBrowserTimeZone } from '@/utils/browser-date-time'
 
 const itemVariants = cv({
@@ -29,30 +31,29 @@ function formatScheduledAt(scheduledAt?: string) {
 }
 
 export function EventItem({ event }: { event: CueSheetEvent }) {
-    const navigate = useNavigate()
+    const [open, setOpen] = useState(false)
     const { state: { tracksByEventId } } = useCueSheet()
     const trackCount = tracksByEventId[event.id]?.length ?? 0
     const scheduledAt = formatScheduledAt(event.scheduledAt)
 
     return (
-        <div
-            className={cn(itemVariants(), 'cursor-pointer hover:bg-background-primary-hover transition-colors')}
-            onClick={() => navigate(`/cue-sheet/events/${event.id}`)}
-            role="button"
-            tabIndex={0}
-            onKeyDown={(e) => { if (e.key === 'Enter') navigate(`/cue-sheet/events/${event.id}`) }}
-        >
-            <div>
-                <Label.sm>{event.title}</Label.sm>
-                <Paragraph.sm className="text-tertiary">{event.description}</Paragraph.sm>
-            </div>
-            <div className="flex items-center gap-2 flex-wrap">
-                {scheduledAt && <Badge label={scheduledAt} icon={<CalendarClock />} color="purple" />}
-                <Badge label={formatDuration(event.duration)} icon={<Clock />} variant="outline" />
-                {trackCount > 0 && (
-                    <Badge label={`${trackCount} track${trackCount !== 1 ? 's' : ''}`} icon={<Layers />} color="blue" />
-                )}
-            </div>
-        </div>
+        <Drawer.Root open={open} onOpenChange={setOpen}>
+            <Drawer.Trigger>
+                <div className={cn(itemVariants(), 'cursor-pointer hover:bg-background-primary-hover transition-colors')}>
+                    <div>
+                        <Label.sm>{event.title}</Label.sm>
+                        <Paragraph.sm className="text-tertiary">{event.description}</Paragraph.sm>
+                    </div>
+                    <div className="flex items-center gap-2 flex-wrap">
+                        {scheduledAt && <Badge label={scheduledAt} icon={<CalendarClock />} color="purple" />}
+                        <Badge label={formatDuration(event.duration)} icon={<Clock />} variant="outline" />
+                        {trackCount > 0 && (
+                            <Badge label={`${trackCount} track${trackCount !== 1 ? 's' : ''}`} icon={<Layers />} color="blue" />
+                        )}
+                    </div>
+                </div>
+            </Drawer.Trigger>
+            <EventDrawer event={event} />
+        </Drawer.Root>
     )
 }

--- a/src/features/cue-sheet/run-status.ts
+++ b/src/features/cue-sheet/run-status.ts
@@ -1,0 +1,67 @@
+import type { Checklist, CueSheetEvent } from '@/types/cue-sheet'
+
+function getScheduledTime(value?: string) {
+    return value ? new Date(value).getTime() : Number.MAX_SAFE_INTEGER
+}
+
+function compareScheduledTimeAsc(left?: string, right?: string) {
+    return getScheduledTime(left) - getScheduledTime(right)
+}
+
+function compareScheduledTimeDesc(left?: string, right?: string) {
+    return getScheduledTime(right) - getScheduledTime(left)
+}
+
+function getChecklistCounts(checklist: Checklist) {
+    const topLevelChecked = checklist.items.filter((item) => item.checked).length
+    const topLevelTotal = checklist.items.length
+    const sectionItems = checklist.sections.flatMap((section) => section.items)
+    const sectionChecked = sectionItems.filter((item) => item.checked).length
+
+    return {
+        total: topLevelTotal + sectionItems.length,
+        checked: topLevelChecked + sectionChecked,
+    }
+}
+
+export function isEventRunPast(event: CueSheetEvent, now = Date.now()) {
+    return event.scheduledAt !== undefined && new Date(event.scheduledAt).getTime() < now
+}
+
+export function isChecklistRunComplete(checklist: Checklist) {
+    const { total, checked } = getChecklistCounts(checklist)
+    return total > 0 && total === checked
+}
+
+export function isChecklistRunPastOrComplete(checklist: Checklist, now = Date.now()) {
+    if (isChecklistRunComplete(checklist)) return true
+    return checklist.scheduledAt !== undefined && new Date(checklist.scheduledAt).getTime() < now
+}
+
+export function sortOverviewEventRuns(events: CueSheetEvent[]) {
+    return [...events].sort((left, right) => compareScheduledTimeAsc(left.scheduledAt, right.scheduledAt))
+}
+
+export function sortOverviewChecklistRuns(checklists: Checklist[]) {
+    return [...checklists].sort((left, right) => compareScheduledTimeAsc(left.scheduledAt, right.scheduledAt))
+}
+
+export function partitionEventRuns(events: CueSheetEvent[], now = Date.now()) {
+    const active = events.filter((event) => !isEventRunPast(event, now))
+    const past = events.filter((event) => isEventRunPast(event, now))
+
+    return {
+        active: [...active].sort((left, right) => compareScheduledTimeAsc(left.scheduledAt, right.scheduledAt)),
+        past: [...past].sort((left, right) => compareScheduledTimeDesc(left.scheduledAt, right.scheduledAt)),
+    }
+}
+
+export function partitionChecklistRuns(checklists: Checklist[], now = Date.now()) {
+    const active = checklists.filter((checklist) => !isChecklistRunPastOrComplete(checklist, now))
+    const past = checklists.filter((checklist) => isChecklistRunPastOrComplete(checklist, now))
+
+    return {
+        active: [...active].sort((left, right) => compareScheduledTimeAsc(left.scheduledAt, right.scheduledAt)),
+        past: [...past].sort((left, right) => compareScheduledTimeDesc(left.scheduledAt, right.scheduledAt)),
+    }
+}

--- a/src/features/cue-sheet/use-checklist-run-filters.ts
+++ b/src/features/cue-sheet/use-checklist-run-filters.ts
@@ -18,7 +18,7 @@ export type ChecklistRunFilters = {
 
 const defaultFilters: ChecklistRunFilters = {
     search: '',
-    includePast: false,
+    includePast: true,
     dateRange: { start: '', end: '' },
     itemCount: { min: '', max: '' },
     completion: 'all',

--- a/src/features/cue-sheet/use-event-run-filters.ts
+++ b/src/features/cue-sheet/use-event-run-filters.ts
@@ -17,7 +17,7 @@ export type EventRunFilters = {
 
 const defaultFilters: EventRunFilters = {
     search: '',
-    includePast: false,
+    includePast: true,
     dateRange: { start: '', end: '' },
     trackCount: { min: '', max: '' },
     cueCount: { min: '', max: '' },

--- a/src/features/equipment/booking-drawer.tsx
+++ b/src/features/equipment/booking-drawer.tsx
@@ -5,16 +5,19 @@ import { Button } from "@/components/controls/button";
 import { Paragraph, Title } from "@/components/display/text";
 import { MetaRow } from "@/components/display/meta-row";
 import { Input } from "@/components/form/input";
+import { Modal } from "@/components/overlays/modal";
 import { UnsavedChangesModal } from "@/features/requests/unsaved-changes-modal";
 import { useBookingStore } from "./use-booking-store";
 import { useEquipment } from "./equipment-provider";
 import { useFeedback } from "@/components/feedback/feedback-provider";
+import { fetchEquipmentById } from "@/data/fetch-equipment";
+import { deleteBooking } from "@/data/mutate-booking";
 import {
   bookingStatusLabel,
   bookingStatusColor,
 } from "@/types/equipment";
 import type { Booking, BookingStatus } from "@/types/equipment";
-import { Calendar, Check, Clock, Loader, Package, StickyNote, User, X } from "lucide-react";
+import { Calendar, Check, Clock, Loader, Package, StickyNote, Trash2, User, X } from "lucide-react";
 import { useCallback, useEffect, useState, type RefObject } from "react";
 import { getErrorMessage } from "@/utils/get-error-message";
 import { formatUtcIsoForBrowserDateTimeInput, parseBrowserDateTimeInputToUtcIso } from "@/utils/browser-date-time";
@@ -45,11 +48,13 @@ export function BookingDrawer({ booking, onBookingClose, isDirtyRef, requestClos
 }
 
 function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestCloseRef }: BookingDrawerProps) {
-  const { actions: drawerActions } = useDrawer();
-  const { toast } = useFeedback();
-  const { actions: { syncBooking } } = useEquipment();
+    const { actions: drawerActions } = useDrawer();
+    const { toast } = useFeedback();
+    const { actions: { syncBooking, syncEquipment, removeBooking } } = useEquipment();
 
-  const [showUnsavedModal, setShowUnsavedModal] = useState(false);
+    const [showUnsavedModal, setShowUnsavedModal] = useState(false);
+    const [deleteOpen, setDeleteOpen] = useState(false);
+    const [isDeleting, setIsDeleting] = useState(false);
 
   const store = useBookingStore(booking, { syncBooking });
 
@@ -84,16 +89,24 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
 
   const handleSave = useCallback(async () => {
     try {
-      await store.actions.save();
+      const savedBooking = await store.actions.save();
+      const refreshedEquipment = await fetchEquipmentById(savedBooking.equipmentId);
+      if (refreshedEquipment) {
+        syncEquipment(refreshedEquipment);
+      }
       toast({ title: "Booking saved", variant: "success" });
     } catch (error) {
       toast({ title: "Failed to save booking", description: getErrorMessage(error, "The booking could not be saved."), variant: "error" });
     }
-  }, [store.actions, toast]);
+  }, [store.actions, syncEquipment, toast]);
 
   async function handleModalSave() {
     try {
-      await store.actions.save();
+      const savedBooking = await store.actions.save();
+      const refreshedEquipment = await fetchEquipmentById(savedBooking.equipmentId);
+      if (refreshedEquipment) {
+        syncEquipment(refreshedEquipment);
+      }
       toast({ title: "Booking saved", variant: "success" });
       setShowUnsavedModal(false);
       closeDrawer();
@@ -112,6 +125,25 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
     setShowUnsavedModal(false);
   }
 
+  const handleDelete = useCallback(async () => {
+    setIsDeleting(true);
+    try {
+      await deleteBooking(booking.id);
+      removeBooking(booking.id);
+      const refreshedEquipment = await fetchEquipmentById(booking.equipmentId);
+      if (refreshedEquipment) {
+        syncEquipment(refreshedEquipment);
+      }
+      toast({ title: "Booking deleted", variant: "success" });
+      setDeleteOpen(false);
+      closeDrawer();
+    } catch (error) {
+      toast({ title: "Failed to delete booking", description: getErrorMessage(error, "The booking could not be deleted."), variant: "error" });
+    } finally {
+      setIsDeleting(false);
+    }
+  }, [booking.equipmentId, booking.id, closeDrawer, removeBooking, syncEquipment, toast]);
+
   const draft = store.state.draft;
 
   return (
@@ -119,6 +151,7 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
       <Drawer.Header className="flex items-center gap-1">
         <Button.Icon variant="ghost" icon={<X />} onClick={handleClose} />
         <div className="flex-1" />
+        <Button.Icon variant="danger-secondary" icon={<Trash2 />} onClick={() => setDeleteOpen(true)} />
       </Drawer.Header>
 
       <Drawer.Content className="py-4">
@@ -238,6 +271,30 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
         onCancel={handleModalCancel}
         isSaving={store.state.isSaving}
       />
+
+      <Modal.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
+        <Modal.Portal>
+          <Modal.Backdrop />
+          <Modal.Positioner>
+            <Modal.Panel>
+              <Modal.Header>
+                <Title.h6>Delete Booking</Title.h6>
+              </Modal.Header>
+              <Modal.Content className="p-4">
+                <Paragraph.sm className="text-secondary">
+                  Are you sure you want to delete this booking? This action cannot be undone.
+                </Paragraph.sm>
+              </Modal.Content>
+              <Modal.Footer className="justify-end">
+                <Button variant="secondary" onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                <Button variant="danger" onClick={handleDelete} disabled={isDeleting}>
+                  {isDeleting ? "Deleting..." : "Delete Booking"}
+                </Button>
+              </Modal.Footer>
+            </Modal.Panel>
+          </Modal.Positioner>
+        </Modal.Portal>
+      </Modal.Root>
     </>
   );
 }

--- a/src/features/equipment/create-booking-modal.tsx
+++ b/src/features/equipment/create-booking-modal.tsx
@@ -1,0 +1,149 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/overlays/modal";
+import { Button } from "@/components/controls/button";
+import { Input } from "@/components/form/input";
+import { FormLabel } from "@/components/form/form-label";
+import { Label } from "@/components/display/text";
+import type { Equipment } from "@/types/equipment";
+import type { CreateBookingParams } from "@/data/mutate-booking";
+import { formatUtcIsoForBrowserDateTimeInput, parseBrowserDateTimeInputToUtcIso } from "@/utils/browser-date-time";
+
+type CreateBookingModalProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  equipment: Equipment[];
+  onCreate: (params: CreateBookingParams) => Promise<void> | void;
+};
+
+function getDefaultExpectedReturnValue(checkedOutDate: string) {
+  const nextDate = new Date(checkedOutDate);
+  nextDate.setHours(nextDate.getHours() + 24);
+  return nextDate.toISOString();
+}
+
+export function CreateBookingModal({ open, onOpenChange, equipment, onCreate }: CreateBookingModalProps) {
+  const availableEquipment = useMemo(
+    () => equipment.filter((item) => item.status !== "maintenance"),
+    [equipment],
+  );
+  const defaultEquipment = availableEquipment[0] ?? null;
+  const defaultCheckedOutDate = new Date().toISOString();
+
+  const [equipmentId, setEquipmentId] = useState(defaultEquipment?.id ?? "");
+  const [bookedBy, setBookedBy] = useState("");
+  const [checkedOutDate, setCheckedOutDate] = useState(formatUtcIsoForBrowserDateTimeInput(defaultCheckedOutDate));
+  const [expectedReturnAt, setExpectedReturnAt] = useState(
+    formatUtcIsoForBrowserDateTimeInput(getDefaultExpectedReturnValue(defaultCheckedOutDate)),
+  );
+  const [notes, setNotes] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const resetForm = useCallback(() => {
+    const nextCheckedOutDate = new Date().toISOString();
+    setEquipmentId(defaultEquipment?.id ?? "");
+    setBookedBy("");
+    setCheckedOutDate(formatUtcIsoForBrowserDateTimeInput(nextCheckedOutDate));
+    setExpectedReturnAt(formatUtcIsoForBrowserDateTimeInput(getDefaultExpectedReturnValue(nextCheckedOutDate)));
+    setNotes("");
+  }, [defaultEquipment]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    resetForm();
+  }, [open, resetForm]);
+
+  const canSubmit = equipmentId.length > 0 && bookedBy.trim().length > 0 && checkedOutDate.length > 0 && expectedReturnAt.length > 0 && !isSubmitting;
+
+  const handleOpenChange = useCallback((nextOpen: boolean) => {
+    onOpenChange(nextOpen);
+    if (!nextOpen) {
+      resetForm();
+    }
+  }, [onOpenChange, resetForm]);
+
+  const handleSubmit = useCallback(async () => {
+    if (!canSubmit) {
+      return;
+    }
+
+    const selectedEquipment = availableEquipment.find((item) => item.id === equipmentId);
+    if (!selectedEquipment) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onCreate({
+        equipmentId: selectedEquipment.id,
+        equipmentName: selectedEquipment.name,
+        bookedBy: bookedBy.trim(),
+        checkedOutDate: parseBrowserDateTimeInputToUtcIso(checkedOutDate),
+        expectedReturnAt: parseBrowserDateTimeInputToUtcIso(expectedReturnAt),
+        notes: notes.trim(),
+        status: "booked",
+      });
+      onOpenChange(false);
+      resetForm();
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [availableEquipment, bookedBy, canSubmit, checkedOutDate, equipmentId, expectedReturnAt, notes, onCreate, onOpenChange, resetForm]);
+
+  return (
+    <Modal.Root open={open} onOpenChange={handleOpenChange}>
+      <Modal.Portal>
+        <Modal.Backdrop />
+        <Modal.Positioner>
+          <Modal.Panel className="max-w-md">
+            <Modal.Header>
+              <Label.md>New Booking</Label.md>
+            </Modal.Header>
+            <Modal.Content>
+              <div className="flex flex-col gap-4 p-4">
+                <div className="flex flex-col gap-1.5">
+                  <FormLabel label="Equipment" required />
+                  <select
+                    value={equipmentId}
+                    onChange={(event) => setEquipmentId(event.target.value)}
+                    className="w-full rounded-md border border-secondary bg-primary px-3 py-2 text-sm text-primary focus:border-brand focus:outline-none focus:ring-1 focus:ring-brand"
+                  >
+                    {availableEquipment.map((item) => (
+                      <option key={item.id} value={item.id}>{item.name}</option>
+                    ))}
+                  </select>
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <FormLabel label="Booked By" required />
+                  <Input value={bookedBy} onChange={(event) => setBookedBy(event.target.value)} placeholder="Name" />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <FormLabel label="Checked Out" required />
+                  <Input type="datetime-local" value={checkedOutDate} onChange={(event) => setCheckedOutDate(event.target.value)} />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <FormLabel label="Expected Return" required />
+                  <Input type="datetime-local" value={expectedReturnAt} onChange={(event) => setExpectedReturnAt(event.target.value)} />
+                </div>
+                <div className="flex flex-col gap-1.5">
+                  <FormLabel label="Notes" optional />
+                  <Input value={notes} onChange={(event) => setNotes(event.target.value)} placeholder="Notes" />
+                </div>
+              </div>
+            </Modal.Content>
+            <Modal.Footer>
+              <Button onClick={handleSubmit} disabled={!canSubmit}>
+                {isSubmitting ? "Creating..." : "Create Booking"}
+              </Button>
+              <Modal.Close>
+                <Button variant="secondary">Cancel</Button>
+              </Modal.Close>
+            </Modal.Footer>
+          </Modal.Panel>
+        </Modal.Positioner>
+      </Modal.Portal>
+    </Modal.Root>
+  );
+}

--- a/src/features/equipment/equipment-drawer.tsx
+++ b/src/features/equipment/equipment-drawer.tsx
@@ -61,7 +61,7 @@ function EquipmentDrawerContent({ equipment, onEquipmentClose, isDirtyRef, reque
   const { state: drawerState, actions: drawerActions } = useDrawer();
   const navigate = useNavigate();
   const { toast } = useFeedback();
-  const { actions: { syncEquipment, removeEquipment } } = useEquipment();
+  const { actions: { syncEquipment, removeEquipment, removeBookingsByEquipmentId } } = useEquipment();
 
   const [bookings, setBookings] = useState<Booking[]>([]);
   const [isLoadingBookings, setIsLoadingBookings] = useState(false);
@@ -157,6 +157,7 @@ function EquipmentDrawerContent({ equipment, onEquipmentClose, isDirtyRef, reque
     try {
       await deleteEquipment(equipment.id);
       removeEquipment(equipment.id);
+      removeBookingsByEquipmentId(equipment.id);
       toast({ title: "Equipment deleted", variant: "success" });
       setShowDeleteModal(false);
       closeDrawer();

--- a/src/features/equipment/equipment-provider.tsx
+++ b/src/features/equipment/equipment-provider.tsx
@@ -17,6 +17,8 @@ type EquipmentContextValue = {
     syncEquipment: (equipment: Equipment) => void;
     removeEquipment: (id: string) => void;
     syncBooking: (booking: Booking) => void;
+    removeBooking: (id: string) => void;
+    removeBookingsByEquipmentId: (equipmentId: string) => void;
   };
 };
 
@@ -46,7 +48,22 @@ export function EquipmentProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const syncBooking = useCallback((updated: Booking) => {
-    setBookings((prev) => prev.map((b) => (b.id === updated.id ? updated : b)));
+    setBookings((prev) => {
+      const exists = prev.some((booking) => booking.id === updated.id);
+      if (!exists) {
+        return [updated, ...prev];
+      }
+
+      return prev.map((booking) => (booking.id === updated.id ? updated : booking));
+    });
+  }, []);
+
+  const removeBooking = useCallback((id: string) => {
+    setBookings((prev) => prev.filter((booking) => booking.id !== id));
+  }, []);
+
+  const removeBookingsByEquipmentId = useCallback((equipmentId: string) => {
+    setBookings((prev) => prev.filter((booking) => booking.equipmentId !== equipmentId));
   }, []);
 
   const loadEquipment = useCallback(async () => {
@@ -88,9 +105,9 @@ export function EquipmentProvider({ children }: { children: ReactNode }) {
   const value = useMemo(
     () => ({
       state: { equipment, bookings, isLoadingEquipment, isLoadingBookings },
-      actions: { loadEquipment, loadBookings, addEquipment, syncEquipment, removeEquipment, syncBooking },
+      actions: { loadEquipment, loadBookings, addEquipment, syncEquipment, removeEquipment, syncBooking, removeBooking, removeBookingsByEquipmentId },
     }),
-    [equipment, bookings, isLoadingEquipment, isLoadingBookings, loadEquipment, loadBookings, addEquipment, syncEquipment, removeEquipment, syncBooking],
+    [equipment, bookings, isLoadingEquipment, isLoadingBookings, loadEquipment, loadBookings, addEquipment, syncEquipment, removeEquipment, syncBooking, removeBooking, removeBookingsByEquipmentId],
   );
 
   return <EquipmentContext.Provider value={value}>{children}</EquipmentContext.Provider>;

--- a/src/screens/broadcast/detail/page.tsx
+++ b/src/screens/broadcast/detail/page.tsx
@@ -78,6 +78,7 @@ export function PlaylistDetailScreen() {
   const [dragActiveItem, setDragActiveItem] = useState<MediaItem | null>(null)
   const [dragActiveCue, setDragActiveCue] = useState<Cue | null>(null)
   const [dropInsertIndex, setDropInsertIndex] = useState<number | null>(null)
+  const persistedPlaylistRef = useRef<Playlist | null>(null)
   const mediaPanelRef = useRef<HTMLDivElement>(null)
   const handleBrowseMedia = useCallback(() => {
     const input = mediaPanelRef.current?.querySelector("input")
@@ -93,6 +94,7 @@ export function PlaylistDetailScreen() {
     const fromContext = contextPlaylists.find((p) => p.id === id)
     if (fromContext) {
       const timerId = window.setTimeout(() => {
+        persistedPlaylistRef.current = fromContext
         setPlaylist(fromContext)
         setIsLoading(false)
       }, 0)
@@ -101,6 +103,7 @@ export function PlaylistDetailScreen() {
     let cancelled = false
     fetchPlaylistById(id).then((data) => {
       if (!cancelled) {
+        persistedPlaylistRef.current = data ?? null
         setPlaylist(data ?? null)
         setIsLoading(false)
       }
@@ -133,36 +136,96 @@ export function PlaylistDetailScreen() {
     setPlaylist((prev) => (prev ? { ...prev, [field]: value } : prev))
   }, [])
 
-  const syncPlaylistUpdate = useCallback((updated: Playlist) => {
-    const previousPlaylist = playlist
-
-    if (!previousPlaylist) {
-      return
-    }
-
+  const persistPlaylistMetadata = useCallback((updated: Playlist, previous: Playlist) => {
     setPlaylist(updated)
     syncPlaylist(updated)
     updatePlaylist(updated)
       .then((savedPlaylist) => {
-        setPlaylist(savedPlaylist)
-        syncPlaylist(savedPlaylist)
+        const nextPlaylist = {
+          ...savedPlaylist,
+          cues: previous.cues,
+          videoSettings: updated.videoSettings,
+        }
+        persistedPlaylistRef.current = nextPlaylist
+        setPlaylist(nextPlaylist)
+        syncPlaylist(nextPlaylist)
       })
       .catch((error) => {
-        setPlaylist(previousPlaylist)
-        syncPlaylist(previousPlaylist)
+        setPlaylist(previous)
+        syncPlaylist(previous)
         toast({ title: "Failed to save", description: getErrorMessage(error, "The playlist could not be updated."), variant: "error" })
       })
-  }, [playlist, syncPlaylist, toast])
+  }, [syncPlaylist, toast])
+
+  const persistPlaylistQueue = useCallback((updated: Playlist, previous: Playlist) => {
+    setPlaylist(updated)
+    syncPlaylist(updated)
+
+    Promise.all([
+      updatePlaylist(updated),
+      updatePlaylistCues(updated.id, updated.cues),
+    ])
+      .then(([savedPlaylist, savedCues]) => {
+        const nextPlaylist = {
+          ...savedPlaylist,
+          cues: savedCues,
+          videoSettings: updated.videoSettings,
+        }
+        persistedPlaylistRef.current = nextPlaylist
+        setPlaylist(nextPlaylist)
+        syncPlaylist(nextPlaylist)
+      })
+      .catch((error) => {
+        setPlaylist(previous)
+        syncPlaylist(previous)
+        toast({ title: "Failed to save", description: getErrorMessage(error, "The playlist could not be updated."), variant: "error" })
+      })
+  }, [syncPlaylist, toast])
 
   const handleNameSave = useCallback((name: string) => {
     if (!playlist) return
-    syncPlaylistUpdate({ ...playlist, name })
-  }, [playlist, syncPlaylistUpdate])
+    persistPlaylistMetadata({ ...playlist, name }, playlist)
+  }, [persistPlaylistMetadata, playlist])
 
   const handleStatusChange = useCallback((status: PlaylistStatus) => {
     if (!playlist) return
-    syncPlaylistUpdate({ ...playlist, status })
-  }, [playlist, syncPlaylistUpdate])
+    persistPlaylistMetadata({ ...playlist, status }, playlist)
+  }, [persistPlaylistMetadata, playlist])
+
+  const handleDescriptionChange = useCallback((value: string) => {
+    updateField("description", value)
+  }, [updateField])
+
+  const handleDescriptionBlur = useCallback(() => {
+    const persistedPlaylist = persistedPlaylistRef.current
+
+    if (!playlist || !persistedPlaylist || playlist.description === persistedPlaylist.description) {
+      return
+    }
+
+    persistPlaylistMetadata(playlist, playlist)
+  }, [persistPlaylistMetadata, playlist])
+
+  const handleDefaultImageDurationChange = useCallback((value: string) => {
+    const nextValue = parseInt(value, 10)
+    if (!Number.isNaN(nextValue) && nextValue > 0) {
+      updateField("defaultImageDuration", nextValue)
+    }
+  }, [updateField])
+
+  const handleDefaultImageDurationBlur = useCallback(() => {
+    const persistedPlaylist = persistedPlaylistRef.current
+
+    if (!playlist) {
+      return
+    }
+
+    if (!persistedPlaylist || playlist.defaultImageDuration === persistedPlaylist.defaultImageDuration) {
+      return
+    }
+
+    persistPlaylistMetadata(playlist, playlist)
+  }, [persistPlaylistMetadata, playlist])
 
   // ─── Add media to queue ─────────────────────────────
 
@@ -177,83 +240,66 @@ export function PlaylistDetailScreen() {
       durationOverride: null,
     }
     const newCues = [...playlist.cues, newCue]
-    const previousCues = playlist.cues
-    setPlaylist((prev) => (prev ? { ...prev, cues: newCues } : prev))
-    updatePlaylistCues(playlist.id, newCues).catch((error) => {
-      setPlaylist((prev) => (prev ? { ...prev, cues: previousCues } : prev))
-      toast({ title: "Failed to save", description: getErrorMessage(error, "The cue could not be added."), variant: "error" })
-    })
-  }, [playlist, toast])
+    persistPlaylistQueue({ ...playlist, cues: newCues }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   // ─── Cue mutations ──────────────────────────────────
 
   const handleRemoveCue = useCallback((cueId: string) => {
-    setPlaylist((prev) => {
-      if (!prev) return prev
-      const cues = prev.cues
-        .filter((c) => c.id !== cueId)
-        .map((c, i) => ({ ...c, order: i + 1 }))
-      return { ...prev, cues }
-    })
-  }, [])
+    if (!playlist) return
+    const cues = playlist.cues
+      .filter((c) => c.id !== cueId)
+      .map((c, i) => ({ ...c, order: i + 1 }))
+    persistPlaylistQueue({ ...playlist, cues }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   const handleUpdateCue = useCallback((updatedCue: Cue) => {
-    setPlaylist((prev) => {
-      if (!prev) return prev
-      const cues = prev.cues.map((c) => c.id === updatedCue.id ? updatedCue : c)
-      return { ...prev, cues }
-    })
-  }, [])
+    if (!playlist) return
+    const cues = playlist.cues.map((cue) => cue.id === updatedCue.id ? updatedCue : cue)
+    persistPlaylistQueue({ ...playlist, cues }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   const handleDuplicateCue = useCallback((cueId: string) => {
-    setPlaylist((prev) => {
-      if (!prev) return prev
-      const idx = prev.cues.findIndex((c) => c.id === cueId)
-      if (idx === -1) return prev
-      const original = prev.cues[idx]
-      const clone: Cue = {
-        ...original,
-        id: crypto.randomUUID(),
-      }
-      const newCues = [...prev.cues]
-      newCues.splice(idx + 1, 0, clone)
-      return { ...prev, cues: newCues.map((c, i) => ({ ...c, order: i + 1 })) }
-    })
-  }, [])
+    if (!playlist) return
+    const idx = playlist.cues.findIndex((cue) => cue.id === cueId)
+    if (idx === -1) return
+    const original = playlist.cues[idx]
+    const clone: Cue = {
+      ...original,
+      id: crypto.randomUUID(),
+    }
+    const newCues = [...playlist.cues]
+    newCues.splice(idx + 1, 0, clone)
+    persistPlaylistQueue({ ...playlist, cues: newCues.map((cue, index) => ({ ...cue, order: index + 1 })) }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   const handleMoveToTop = useCallback((cueId: string) => {
-    setPlaylist((prev) => {
-      if (!prev) return prev
-      const idx = prev.cues.findIndex((c) => c.id === cueId)
-      if (idx <= 0) return prev
-      const cues = [...prev.cues]
-      const [moved] = cues.splice(idx, 1)
-      cues.unshift(moved)
-      return { ...prev, cues: cues.map((c, i) => ({ ...c, order: i + 1 })) }
-    })
-  }, [])
+    if (!playlist) return
+    const idx = playlist.cues.findIndex((cue) => cue.id === cueId)
+    if (idx <= 0) return
+    const cues = [...playlist.cues]
+    const [moved] = cues.splice(idx, 1)
+    cues.unshift(moved)
+    persistPlaylistQueue({ ...playlist, cues: cues.map((cue, index) => ({ ...cue, order: index + 1 })) }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   const handleMoveToBottom = useCallback((cueId: string) => {
-    setPlaylist((prev) => {
-      if (!prev) return prev
-      const idx = prev.cues.findIndex((c) => c.id === cueId)
-      if (idx === -1 || idx === prev.cues.length - 1) return prev
-      const cues = [...prev.cues]
-      const [moved] = cues.splice(idx, 1)
-      cues.push(moved)
-      return { ...prev, cues: cues.map((c, i) => ({ ...c, order: i + 1 })) }
-    })
-  }, [])
+    if (!playlist) return
+    const idx = playlist.cues.findIndex((cue) => cue.id === cueId)
+    if (idx === -1 || idx === playlist.cues.length - 1) return
+    const cues = [...playlist.cues]
+    const [moved] = cues.splice(idx, 1)
+    cues.push(moved)
+    persistPlaylistQueue({ ...playlist, cues: cues.map((cue, index) => ({ ...cue, order: index + 1 })) }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   const handleToggleDisable = useCallback((cueId: string) => {
-    setPlaylist((prev) => {
-      if (!prev) return prev
-      return {
-        ...prev,
-        cues: prev.cues.map((c) => c.id === cueId ? { ...c, disabled: !c.disabled } : c),
-      }
-    })
-  }, [])
+    if (!playlist) return
+    persistPlaylistQueue({
+      ...playlist,
+      cues: playlist.cues.map((cue) => cue.id === cueId ? { ...cue, disabled: !cue.disabled } : cue),
+    }, playlist)
+  }, [persistPlaylistQueue, playlist])
 
   // ─── Drag from media → queue ────────────────────────
 
@@ -305,18 +351,12 @@ export function PlaylistDetailScreen() {
       const overIndex = playlist.cues.findIndex((c) => c.id === overId)
       if (overIndex === -1) return
 
-      const previousCues = playlist.cues
       const reordered = [...playlist.cues]
       const [moved] = reordered.splice(activeCueIndex, 1)
       reordered.splice(overIndex, 0, moved)
       const renumbered = reordered.map((c, i) => ({ ...c, order: i + 1 }))
 
-      setPlaylist((prev) => (prev ? { ...prev, cues: renumbered } : prev))
-
-      updatePlaylistCues(playlist.id, renumbered).catch((error) => {
-        setPlaylist((prev) => (prev ? { ...prev, cues: previousCues } : prev))
-        toast({ title: "Failed to save", description: getErrorMessage(error, "The cue order could not be updated."), variant: "error" })
-      })
+      persistPlaylistQueue({ ...playlist, cues: renumbered }, playlist)
       return
     }
 
@@ -341,17 +381,11 @@ export function PlaylistDetailScreen() {
       durationOverride: null,
     }
 
-    const previousCues = playlist.cues
     const newCues = [...playlist.cues]
     newCues.splice(insertAt, 0, newCue)
     const renumbered = newCues.map((c, i) => ({ ...c, order: i + 1 }))
 
-    setPlaylist((prev) => (prev ? { ...prev, cues: renumbered } : prev))
-
-    updatePlaylistCues(playlist.id, renumbered).catch((error) => {
-      setPlaylist((prev) => (prev ? { ...prev, cues: previousCues } : prev))
-      toast({ title: "Failed to save", description: getErrorMessage(error, "The cue could not be added."), variant: "error" })
-    })
+    persistPlaylistQueue({ ...playlist, cues: renumbered }, playlist)
   }
 
   function handleDragCancel() {
@@ -445,7 +479,8 @@ export function PlaylistDetailScreen() {
                     className="all-unset w-full text-xs text-primary placeholder:text-quaternary resize-none"
                     rows={2}
                     value={playlist.description}
-                    onChange={(e) => updateField("description", e.target.value)}
+                    onChange={(e) => handleDescriptionChange(e.target.value)}
+                    onBlur={handleDescriptionBlur}
                     placeholder="Describe this playlist..."
                   />
                 </MetaRow>
@@ -526,7 +561,7 @@ export function PlaylistDetailScreen() {
                       <Paragraph.xs className="truncate flex-1">{playlist.backgroundMusicName ?? "Audio"}</Paragraph.xs>
                       <audio src={playlist.backgroundMusicUrl} controls preload="metadata" className="h-6 max-w-40" />
                       <button
-                        onClick={() => syncPlaylistUpdate({ ...playlist, backgroundMusicId: null, backgroundMusicUrl: null, backgroundMusicName: null })}
+                        onClick={() => persistPlaylistMetadata({ ...playlist, backgroundMusicId: null, backgroundMusicUrl: null, backgroundMusicName: null }, playlist)}
                         className="p-0.5 rounded hover:bg-secondary cursor-pointer text-quaternary hover:text-secondary transition-colors"
                       >
                         <X className="size-3.5" />
@@ -541,12 +576,12 @@ export function PlaylistDetailScreen() {
                         {media.filter((m) => m.type === "audio").map((audioItem) => (
                           <Dropdown.Item
                             key={audioItem.id}
-                            onSelect={() => syncPlaylistUpdate({
+                            onSelect={() => persistPlaylistMetadata({
                               ...playlist,
                               backgroundMusicId: audioItem.id,
                               backgroundMusicUrl: audioItem.url,
                               backgroundMusicName: audioItem.name,
-                            })}
+                            }, playlist)}
                           >
                             <Music className="size-4" />
                             {audioItem.name}
@@ -567,10 +602,8 @@ export function PlaylistDetailScreen() {
                     <Label.xs className="text-tertiary">Image</Label.xs>
                     <Input
                       value={String(playlist.defaultImageDuration)}
-                      onChange={(e) => {
-                        const val = parseInt(e.target.value, 10)
-                        if (!isNaN(val) && val > 0) updateField("defaultImageDuration", val)
-                      }}
+                      onChange={(e) => handleDefaultImageDurationChange(e.target.value)}
+                      onBlur={handleDefaultImageDurationBlur}
                       placeholder="sec"
                       className="!w-14 !py-0.5 !px-1.5"
                     />

--- a/src/screens/broadcast/media/detail/page.tsx
+++ b/src/screens/broadcast/media/detail/page.tsx
@@ -87,7 +87,7 @@ export function MediaDetailScreen() {
     if (!item) return
     setIsDeleting(true)
     try {
-      await deleteMediaItem(item.id)
+      await deleteMediaItem(item)
       removeMediaItem(item.id)
       toast({ title: "Media deleted", variant: "success" })
       navigate("/broadcast/media")

--- a/src/screens/broadcast/media/page.tsx
+++ b/src/screens/broadcast/media/page.tsx
@@ -57,7 +57,7 @@ export function BroadcastMediaScreen() {
     if (!pendingDelete) return
     setIsDeleting(true)
     try {
-      await deleteMediaItem(pendingDelete.id)
+      await deleteMediaItem(pendingDelete)
       removeMediaItem(pendingDelete.id)
       toast({ title: "Media deleted", variant: "success" })
       setSelectedItem(null)

--- a/src/screens/cue-sheet/checklist/detail/page.tsx
+++ b/src/screens/cue-sheet/checklist/detail/page.tsx
@@ -6,27 +6,42 @@ import { Header } from '@/components/display/header'
 import { Label, Paragraph, Title } from '@/components/display/text'
 import { Spinner } from '@/components/feedback/spinner'
 import { Badge } from '@/components/display/badge'
+import { Modal } from '@/components/overlays/modal'
+import { InlineEditableText } from '@/components/form/inline-editable-text'
+import { useFeedback } from '@/components/feedback/feedback-provider'
 import { useCueSheet } from '@/features/cue-sheet/cue-sheet-provider'
 import { ChecklistContent, getChecklistCounts, type AddRequest } from '@/features/cue-sheet/checklist-content'
-import { FolderPlus, ListChecks, Plus, SquarePlus } from 'lucide-react'
-import { useEffect, useState } from 'react'
-import { useParams } from 'react-router-dom'
+import type { Checklist } from '@/types/cue-sheet'
+import { FolderPlus, ListChecks, Plus, SquarePlus, Trash2, TriangleAlert } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 
 export function CueSheetChecklistDetailScreen() {
     const { id } = useParams<{ id: string }>()
     const {
         state: { checklists },
-        actions: { loadChecklists, syncChecklist },
+        actions: { loadChecklists, syncChecklist, removeChecklist },
     } = useCueSheet()
+    const { toast } = useFeedback()
+    const navigate = useNavigate()
 
     const checklist = checklists.find((c) => c.id === id) ?? null
     const [addRequest, setAddRequest] = useState<AddRequest>(null)
+    const [deleteOpen, setDeleteOpen] = useState(false)
 
     useBreadcrumbOverride(id ?? '', checklist?.name)
 
     useEffect(() => {
         loadChecklists()
     }, [loadChecklists])
+
+    const handleChecklistUpdate = useCallback(async (nextChecklist: Checklist) => {
+        try {
+            await syncChecklist(nextChecklist)
+        } catch (error) {
+            toast({ title: 'Failed to save checklist', description: error instanceof Error ? error.message : 'The checklist could not be saved.', variant: 'error' })
+        }
+    }, [syncChecklist, toast])
 
     if (!checklist) {
         return (
@@ -38,13 +53,28 @@ export function CueSheetChecklistDetailScreen() {
 
     const { total, checked } = getChecklistCounts(checklist)
 
+    async function handleDelete() {
+        if (!id) return
+
+        try {
+            await removeChecklist(id)
+            toast({ title: 'Checklist deleted', variant: 'success' })
+            navigate('/cue-sheet/checklist')
+        } catch (error) {
+            toast({ title: 'Failed to delete checklist', description: error instanceof Error ? error.message : 'The checklist could not be deleted.', variant: 'error' })
+        }
+    }
+
     return (
         <section className="mx-auto max-w-content-sm">
             <Header.Root className="px-4 pt-12">
                 <Header.Lead className="gap-2">
-                    <Title.h5>{checklist.name}</Title.h5>
+                    <Title.h5>
+                        <InlineEditableText value={checklist.name} onSave={(name) => { void handleChecklistUpdate({ ...checklist, name }) }} className="title-h5" />
+                    </Title.h5>
                 </Header.Lead>
                 <Header.Trail>
+                    <Button.Icon variant="danger-secondary" icon={<Trash2 />} onClick={() => setDeleteOpen(true)} />
                     <Dropdown.Root placement="bottom">
                         <Dropdown.Trigger>
                             <Button.Icon variant="secondary" icon={<Plus />} />
@@ -69,9 +99,9 @@ export function CueSheetChecklistDetailScreen() {
                     icon={<ListChecks />}
                     color={checked === total && total > 0 ? 'green' : 'gray'}
                 />
-                {checklist.description && (
-                    <Paragraph.sm className="text-tertiary">{checklist.description}</Paragraph.sm>
-                )}
+                <Paragraph.sm className="text-tertiary">
+                    <InlineEditableText value={checklist.description} onSave={(description) => { void handleChecklistUpdate({ ...checklist, description }) }} className="text-sm text-tertiary" placeholder="Add description" />
+                </Paragraph.sm>
             </div>
 
             <Divider className="px-4 my-6" />
@@ -81,12 +111,34 @@ export function CueSheetChecklistDetailScreen() {
                 <div className="rounded-lg border border-secondary overflow-hidden">
                     <ChecklistContent
                         checklist={checklist}
-                        onUpdate={syncChecklist}
+                        onUpdate={(nextChecklist) => { void handleChecklistUpdate(nextChecklist) }}
                         addRequest={addRequest}
                         onAddRequestDismiss={() => setAddRequest(null)}
                     />
                 </div>
             </div>
+            <Modal.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <Modal.Portal>
+                    <Modal.Backdrop />
+                    <Modal.Positioner>
+                        <Modal.Panel>
+                            <Modal.Header>
+                                <Label.md>Delete Checklist</Label.md>
+                            </Modal.Header>
+                            <Modal.Content className="p-4 flex-row gap-4">
+                                <TriangleAlert className="size-8 shrink-0 text-utility-red-600" />
+                                <Paragraph.sm className="text-secondary">
+                                    Are you sure you want to delete this checklist? This action cannot be undone.
+                                </Paragraph.sm>
+                            </Modal.Content>
+                            <Modal.Footer className="justify-end">
+                                <Button variant="secondary" onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                                <Button variant="danger" onClick={handleDelete}>Delete Checklist</Button>
+                            </Modal.Footer>
+                        </Modal.Panel>
+                    </Modal.Positioner>
+                </Modal.Portal>
+            </Modal.Root>
         </section>
     )
 }

--- a/src/screens/cue-sheet/checklist/page.tsx
+++ b/src/screens/cue-sheet/checklist/page.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo } from 'react'
-import { ListChecks, Plus, Search, Settings2 } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { FilePlus2, ListChecks, Plus, Search, Settings2 } from 'lucide-react'
 import { Button } from '@/components/controls/button'
 import { Card } from '@/components/display/card'
 import { Header } from '@/components/display/header'
@@ -10,7 +10,9 @@ import { Drawer } from '@/components/overlays/drawer'
 import { Dropdown } from '@/components/overlays/dropdown'
 import { ChecklistItemCard } from '@/features/cue-sheet/checklist-item'
 import { ChecklistRunFilterDrawer } from '@/features/cue-sheet/checklist-run-filter-drawer'
+import { CreateChecklistRunModal, type ChecklistRunSubmit } from '@/features/cue-sheet/create-checklist-run-modal'
 import { useCueSheet } from '@/features/cue-sheet/cue-sheet-provider'
+import { partitionChecklistRuns } from '@/features/cue-sheet/run-status'
 import { useChecklistRunFilters } from '@/features/cue-sheet/use-checklist-run-filters'
 import { routes } from '@/screens/console-routes'
 import type { Checklist } from '@/types/cue-sheet'
@@ -19,9 +21,11 @@ import { useNavigate } from 'react-router-dom'
 export function CueSheetChecklistScreen() {
     const {
         state: { checklists, isLoadingChecklists },
-        actions: { loadChecklists, createChecklistInstance },
+        actions: { loadChecklists, createChecklistInstance, createBlankChecklist },
     } = useCueSheet()
     const navigate = useNavigate()
+    const [modalOpen, setModalOpen] = useState(false)
+    const [modalTemplate, setModalTemplate] = useState<Checklist | null>(null)
 
     useEffect(() => {
         loadChecklists()
@@ -31,10 +35,25 @@ export function CueSheetChecklistScreen() {
     const checklistRuns = useMemo(() => checklists.filter((checklist) => checklist.kind === 'instance'), [checklists])
     const checklistFilters = useChecklistRunFilters(checklistRuns)
     const { filtered, filters, setSearch } = checklistFilters
+    const { active: activeChecklistRuns, past: pastChecklistRuns } = useMemo(() => partitionChecklistRuns(filtered), [filtered])
 
-    const handleCreateRun = useCallback(async (template: Checklist) => {
-        await createChecklistInstance(template)
-    }, [createChecklistInstance])
+    const handlePickBlank = useCallback(() => {
+        setModalTemplate(null)
+        setModalOpen(true)
+    }, [])
+
+    const handlePickTemplate = useCallback((template: Checklist) => {
+        setModalTemplate(template)
+        setModalOpen(true)
+    }, [])
+
+    const handleSubmit = useCallback(async (input: ChecklistRunSubmit) => {
+        if (input.kind === 'template') {
+            await createChecklistInstance(input.template, { name: input.name, description: input.description, scheduledAt: input.scheduledAt })
+        } else {
+            await createBlankChecklist({ name: input.name, description: input.description, scheduledAt: input.scheduledAt })
+        }
+    }, [createBlankChecklist, createChecklistInstance])
 
     const handleOpenTemplates = useCallback(() => {
         navigate(`/${routes.cueSheetTemplates}`)
@@ -71,14 +90,19 @@ export function CueSheetChecklistScreen() {
                                     <Button.Icon variant='secondary' icon={<Plus />} />
                                 </Dropdown.Trigger>
                                 <Dropdown.Panel>
+                                    <Dropdown.Item onSelect={handlePickBlank}>
+                                        <FilePlus2 className="size-4" />
+                                        Blank checklist
+                                    </Dropdown.Item>
+                                    {checklistTemplates.length > 0 && <Dropdown.Separator />}
                                     {checklistTemplates.map((checklist) => (
-                                        <Dropdown.Item key={checklist.id} onSelect={() => void handleCreateRun(checklist)}>
+                                        <Dropdown.Item key={checklist.id} onSelect={() => handlePickTemplate(checklist)}>
                                             {checklist.name}
                                         </Dropdown.Item>
                                     ))}
                                     {checklistTemplates.length === 0 && (
                                         <Dropdown.Item onSelect={handleOpenTemplates}>
-                                            Create checklist template
+                                            Manage checklist templates
                                         </Dropdown.Item>
                                     )}
                                 </Dropdown.Panel>
@@ -89,9 +113,24 @@ export function CueSheetChecklistScreen() {
                         {isLoadingChecklists ? (
                             <div className="flex justify-center py-6"><Spinner /></div>
                         ) : filtered.length > 0 ? (
-                            filtered.map((checklist) => (
-                                <ChecklistItemCard key={checklist.id} checklist={checklist} />
-                            ))
+                            <>
+                                {activeChecklistRuns.length > 0 && (
+                                    <>
+                                        <Label.sm className="px-4 pt-2 text-tertiary">Upcoming & In Progress</Label.sm>
+                                        {activeChecklistRuns.map((checklist) => (
+                                            <ChecklistItemCard key={checklist.id} checklist={checklist} />
+                                        ))}
+                                    </>
+                                )}
+                                {pastChecklistRuns.length > 0 && (
+                                    <>
+                                        <Label.sm className="px-4 pt-4 text-tertiary">Past & Completed</Label.sm>
+                                        {pastChecklistRuns.map((checklist) => (
+                                            <ChecklistItemCard key={checklist.id} checklist={checklist} />
+                                        ))}
+                                    </>
+                                )}
+                            </>
                         ) : (
                             <div className="py-8 text-center">
                                 <Paragraph.sm className="text-tertiary">No checklist runs match your filters.</Paragraph.sm>
@@ -100,6 +139,8 @@ export function CueSheetChecklistScreen() {
                     </Card.Content>
                 </Card.Root>
             </div>
+
+            <CreateChecklistRunModal open={modalOpen} onOpenChange={setModalOpen} template={modalTemplate} onSubmit={handleSubmit} />
         </section>
     )
 }

--- a/src/screens/cue-sheet/events/detail/page.tsx
+++ b/src/screens/cue-sheet/events/detail/page.tsx
@@ -1,19 +1,27 @@
 import { useBreadcrumbOverride } from '@/components/navigation/breadcrumb'
 import { InlineEditableText } from '@/components/form/inline-editable-text'
+import { Button } from '@/components/controls/button'
+import { Label, Paragraph } from '@/components/display/text'
+import { Modal } from '@/components/overlays/modal'
 import { Spinner } from '@/components/feedback/spinner'
+import { useFeedback } from '@/components/feedback/feedback-provider'
 import { Timeline } from '@/components/timeline'
 import { useCueSheet } from '@/features/cue-sheet/cue-sheet-provider'
 import { CueModal } from '@/features/cue-sheet/cue-modal'
-import { useCallback, useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import { Trash2, TriangleAlert } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
 import type { Track } from '@/types/cue-sheet'
 
 export function CueSheetEventDetailScreen() {
     const { id } = useParams<{ id: string }>()
     const {
         state: { eventsById, tracksByEventId },
-        actions: { loadEvent, syncTracks, syncEvent },
+        actions: { loadEvent, syncTracks, syncEvent, removeEvent },
     } = useCueSheet()
+    const { toast } = useFeedback()
+    const navigate = useNavigate()
+    const [deleteOpen, setDeleteOpen] = useState(false)
 
     const event = id ? eventsById[id] ?? null : null
     const tracks = id ? tracksByEventId[id] ?? [] : []
@@ -35,6 +43,18 @@ export function CueSheetEventDetailScreen() {
         syncEvent({ ...event, title })
     }, [event, syncEvent])
 
+    const handleDelete = useCallback(async () => {
+        if (!id) return
+
+        try {
+            await removeEvent(id)
+            toast({ title: 'Event deleted', variant: 'success' })
+            navigate('/cue-sheet/events')
+        } catch (error) {
+            toast({ title: 'Failed to delete event', description: error instanceof Error ? error.message : 'The event could not be deleted.', variant: 'error' })
+        }
+    }, [id, navigate, removeEvent, toast])
+
     if (!event) {
         return (
             <section className="flex justify-center py-16 mx-auto max-w-content-sm">
@@ -53,15 +73,40 @@ export function CueSheetEventDetailScreen() {
             >
                 <Timeline.Toolbar
                     renderTitle={() => (
-                        <InlineEditableText
-                            value={event.title}
-                            onSave={handleTitleChange}
-                            className="label-md"
-                        />
+                        <div className="flex items-center gap-2">
+                            <InlineEditableText
+                                value={event.title}
+                                onSave={handleTitleChange}
+                                className="label-md"
+                            />
+                            <Button.Icon variant="danger-secondary" icon={<Trash2 />} onClick={() => setDeleteOpen(true)} />
+                        </div>
                     )}
                 />
                 <CueModal />
             </Timeline.Root>
+            <Modal.Root open={deleteOpen} onOpenChange={setDeleteOpen}>
+                <Modal.Portal>
+                    <Modal.Backdrop />
+                    <Modal.Positioner>
+                        <Modal.Panel>
+                            <Modal.Header>
+                                <Label.md>Delete Event</Label.md>
+                            </Modal.Header>
+                            <Modal.Content className="p-4 flex-row gap-4">
+                                <TriangleAlert className="size-8 shrink-0 text-utility-red-600" />
+                                <Paragraph.sm className="text-secondary">
+                                    Are you sure you want to delete this event? This action cannot be undone.
+                                </Paragraph.sm>
+                            </Modal.Content>
+                            <Modal.Footer className="justify-end">
+                                <Button variant="secondary" onClick={() => setDeleteOpen(false)}>Cancel</Button>
+                                <Button variant="danger" onClick={handleDelete}>Delete Event</Button>
+                            </Modal.Footer>
+                        </Modal.Panel>
+                    </Modal.Positioner>
+                </Modal.Portal>
+            </Modal.Root>
         </section>
     )
 }

--- a/src/screens/cue-sheet/events/page.tsx
+++ b/src/screens/cue-sheet/events/page.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Calendar, Plus, Search, Settings2 } from 'lucide-react'
+import { Calendar, FilePlus2, Plus, Search, Settings2 } from 'lucide-react'
 import { Button } from '@/components/controls/button'
 import { Card } from '@/components/display/card'
 import { Header } from '@/components/display/header'
@@ -9,9 +9,11 @@ import { Spinner } from '@/components/feedback/spinner'
 import { Input } from '@/components/form/input'
 import { Drawer } from '@/components/overlays/drawer'
 import { Dropdown } from '@/components/overlays/dropdown'
+import { CreateEventRunModal, type EventRunSubmit } from '@/features/cue-sheet/create-event-run-modal'
 import { EventItem } from '@/features/cue-sheet/event-item'
 import { EventRunFilterDrawer } from '@/features/cue-sheet/event-run-filter-drawer'
 import { useCueSheet } from '@/features/cue-sheet/cue-sheet-provider'
+import { partitionEventRuns } from '@/features/cue-sheet/run-status'
 import { useEventRunFilters } from '@/features/cue-sheet/use-event-run-filters'
 import type { CueSheetEvent } from '@/types/cue-sheet'
 import { routes } from '@/screens/console-routes'
@@ -19,9 +21,11 @@ import { routes } from '@/screens/console-routes'
 export function CueSheetEventScreen() {
     const {
         state: { events, tracksByEventId, isLoadingEvents },
-        actions: { loadEvents, createEventInstance },
+        actions: { loadEvents, createEventInstance, createBlankEvent },
     } = useCueSheet()
     const navigate = useNavigate()
+    const [modalOpen, setModalOpen] = useState(false)
+    const [modalTemplate, setModalTemplate] = useState<CueSheetEvent | null>(null)
 
     useEffect(() => {
         loadEvents()
@@ -31,11 +35,24 @@ export function CueSheetEventScreen() {
     const eventRuns = useMemo(() => events.filter((event) => event.kind === 'instance'), [events])
     const eventFilters = useEventRunFilters(eventRuns, tracksByEventId)
     const { filtered, filters, setSearch } = eventFilters
+    const { active: activeEventRuns, past: pastEventRuns } = useMemo(() => partitionEventRuns(filtered), [filtered])
 
-    const handleCreateRun = useCallback(async (template: CueSheetEvent) => {
-        const instance = await createEventInstance(template)
+    const handlePickBlank = useCallback(() => {
+        setModalTemplate(null)
+        setModalOpen(true)
+    }, [])
+
+    const handlePickTemplate = useCallback((template: CueSheetEvent) => {
+        setModalTemplate(template)
+        setModalOpen(true)
+    }, [])
+
+    const handleSubmit = useCallback(async (input: EventRunSubmit) => {
+        const instance = input.kind === 'template'
+            ? await createEventInstance(input.template, { title: input.title, description: input.description, scheduledAt: input.scheduledAt })
+            : await createBlankEvent({ title: input.title, description: input.description, scheduledAt: input.scheduledAt, duration: input.duration })
         navigate(`/cue-sheet/events/${instance.id}`)
-    }, [createEventInstance, navigate])
+    }, [createBlankEvent, createEventInstance, navigate])
 
     const handleOpenTemplates = useCallback(() => {
         navigate(`/${routes.cueSheetTemplates}`)
@@ -72,14 +89,19 @@ export function CueSheetEventScreen() {
                                     <Button.Icon variant='secondary' icon={<Plus />} />
                                 </Dropdown.Trigger>
                                 <Dropdown.Panel>
+                                    <Dropdown.Item onSelect={handlePickBlank}>
+                                        <FilePlus2 className="size-4" />
+                                        Blank event
+                                    </Dropdown.Item>
+                                    {eventTemplates.length > 0 && <Dropdown.Separator />}
                                     {eventTemplates.map((event) => (
-                                        <Dropdown.Item key={event.id} onSelect={() => void handleCreateRun(event)}>
+                                        <Dropdown.Item key={event.id} onSelect={() => handlePickTemplate(event)}>
                                             {event.title}
                                         </Dropdown.Item>
                                     ))}
                                     {eventTemplates.length === 0 && (
                                         <Dropdown.Item onSelect={handleOpenTemplates}>
-                                            Create event template
+                                            Manage event templates
                                         </Dropdown.Item>
                                     )}
                                 </Dropdown.Panel>
@@ -90,9 +112,24 @@ export function CueSheetEventScreen() {
                         {isLoadingEvents ? (
                             <div className="flex justify-center py-6"><Spinner /></div>
                         ) : filtered.length > 0 ? (
-                            filtered.map((event) => (
-                                <EventItem key={event.id} event={event} />
-                            ))
+                            <>
+                                {activeEventRuns.length > 0 && (
+                                    <>
+                                        <Label.sm className="px-4 pt-2 text-tertiary">Upcoming & In Progress</Label.sm>
+                                        {activeEventRuns.map((event) => (
+                                            <EventItem key={event.id} event={event} />
+                                        ))}
+                                    </>
+                                )}
+                                {pastEventRuns.length > 0 && (
+                                    <>
+                                        <Label.sm className="px-4 pt-4 text-tertiary">Past</Label.sm>
+                                        {pastEventRuns.map((event) => (
+                                            <EventItem key={event.id} event={event} />
+                                        ))}
+                                    </>
+                                )}
+                            </>
                         ) : (
                             <div className="py-8 text-center">
                                 <Paragraph.sm className="text-tertiary">No event runs match your filters.</Paragraph.sm>
@@ -101,6 +138,8 @@ export function CueSheetEventScreen() {
                     </Card.Content>
                 </Card.Root>
             </div>
+
+            <CreateEventRunModal open={modalOpen} onOpenChange={setModalOpen} template={modalTemplate} onSubmit={handleSubmit} />
         </section>
     )
 }

--- a/src/screens/cue-sheet/page.tsx
+++ b/src/screens/cue-sheet/page.tsx
@@ -5,21 +5,28 @@ import { Label, Paragraph, TextBlock, Title } from '@/components/display/text'
 import { Spinner } from '@/components/feedback/spinner'
 import { EmptyState } from '@/components/feedback/empty-state'
 import { useCueSheet } from '@/features/cue-sheet/cue-sheet-provider'
+import { CreateChecklistRunModal, type ChecklistRunSubmit } from '@/features/cue-sheet/create-checklist-run-modal'
+import { CreateEventRunModal, type EventRunSubmit } from '@/features/cue-sheet/create-event-run-modal'
 import { EventItem } from '@/features/cue-sheet/event-item'
 import { ChecklistItemCard } from '@/features/cue-sheet/checklist-item'
 import { Dropdown } from '@/components/overlays/dropdown'
 import type { CueSheetEvent, Checklist } from '@/types/cue-sheet'
 import { routes } from '@/screens/console-routes'
-import { Calendar, ListChecks, Plus } from 'lucide-react'
-import { useCallback, useEffect, useMemo } from 'react'
+import { isChecklistRunPastOrComplete, isEventRunPast, sortOverviewChecklistRuns, sortOverviewEventRuns } from '@/features/cue-sheet/run-status'
+import { Calendar, FilePlus2, ListChecks, Plus } from 'lucide-react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 
 export function CueSheetOverviewScreen() {
     const {
         state: { events, checklists, isLoadingEvents, isLoadingChecklists },
-        actions: { loadEvents, loadChecklists, createEventInstance, createChecklistInstance },
+        actions: { loadEvents, loadChecklists, createEventInstance, createBlankEvent, createChecklistInstance, createBlankChecklist },
     } = useCueSheet()
     const navigate = useNavigate()
+    const [eventModalOpen, setEventModalOpen] = useState(false)
+    const [eventModalTemplate, setEventModalTemplate] = useState<CueSheetEvent | null>(null)
+    const [checklistModalOpen, setChecklistModalOpen] = useState(false)
+    const [checklistModalTemplate, setChecklistModalTemplate] = useState<Checklist | null>(null)
 
     useEffect(() => {
         loadEvents()
@@ -30,15 +37,50 @@ export function CueSheetOverviewScreen() {
     const eventInstances = useMemo(() => events.filter((event) => event.kind === 'instance'), [events])
     const checklistTemplates = useMemo(() => checklists.filter((checklist) => checklist.kind === 'template'), [checklists])
     const checklistInstances = useMemo(() => checklists.filter((checklist) => checklist.kind === 'instance'), [checklists])
+    const [now] = useState(() => Date.now())
+    const overviewEventRuns = useMemo(
+        () => sortOverviewEventRuns(eventInstances.filter((event) => !isEventRunPast(event, now))),
+        [eventInstances, now],
+    )
+    const overviewChecklistRuns = useMemo(
+        () => sortOverviewChecklistRuns(checklistInstances.filter((checklist) => !isChecklistRunPastOrComplete(checklist, now))),
+        [checklistInstances, now],
+    )
 
-    const handleCreateInstance = useCallback(async (template: CueSheetEvent) => {
-        const instance = await createEventInstance(template)
+    const handlePickBlankEvent = useCallback(() => {
+        setEventModalTemplate(null)
+        setEventModalOpen(true)
+    }, [])
+
+    const handlePickEventTemplate = useCallback((template: CueSheetEvent) => {
+        setEventModalTemplate(template)
+        setEventModalOpen(true)
+    }, [])
+
+    const handleEventSubmit = useCallback(async (input: EventRunSubmit) => {
+        const instance = input.kind === 'template'
+            ? await createEventInstance(input.template, { title: input.title, description: input.description, scheduledAt: input.scheduledAt })
+            : await createBlankEvent({ title: input.title, description: input.description, scheduledAt: input.scheduledAt, duration: input.duration })
         navigate(`/cue-sheet/events/${instance.id}`)
-    }, [createEventInstance, navigate])
+    }, [createBlankEvent, createEventInstance, navigate])
 
-    const handleCreateChecklistRun = useCallback(async (template: Checklist) => {
-        await createChecklistInstance(template)
-    }, [createChecklistInstance])
+    const handlePickBlankChecklist = useCallback(() => {
+        setChecklistModalTemplate(null)
+        setChecklistModalOpen(true)
+    }, [])
+
+    const handlePickChecklistTemplate = useCallback((template: Checklist) => {
+        setChecklistModalTemplate(template)
+        setChecklistModalOpen(true)
+    }, [])
+
+    const handleChecklistSubmit = useCallback(async (input: ChecklistRunSubmit) => {
+        if (input.kind === 'template') {
+            await createChecklistInstance(input.template, { name: input.name, description: input.description, scheduledAt: input.scheduledAt })
+        } else {
+            await createBlankChecklist({ name: input.name, description: input.description, scheduledAt: input.scheduledAt })
+        }
+    }, [createBlankChecklist, createChecklistInstance])
 
     const handleOpenTemplates = useCallback(() => {
         navigate(`/${routes.cueSheetTemplates}`)
@@ -72,7 +114,7 @@ export function CueSheetOverviewScreen() {
                         <Label.sm>Event Runs</Label.sm>
                     </Card.Header>
                     <Card.Content className="p-4">
-                        <TextBlock className="title-h4">{eventInstances.length}</TextBlock>
+                        <TextBlock className="title-h4">{overviewEventRuns.length}</TextBlock>
                     </Card.Content>
                 </Card.Root>
                 <Card.Root>
@@ -81,7 +123,7 @@ export function CueSheetOverviewScreen() {
                         <Label.sm>Checklist Runs</Label.sm>
                     </Card.Header>
                     <Card.Content className="p-4">
-                        <TextBlock className="title-h4">{checklistInstances.length}</TextBlock>
+                        <TextBlock className="title-h4">{overviewChecklistRuns.length}</TextBlock>
                     </Card.Content>
                 </Card.Root>
             </div>
@@ -97,8 +139,13 @@ export function CueSheetOverviewScreen() {
                                 <Button.Icon variant="secondary" icon={<Plus />} />
                             </Dropdown.Trigger>
                             <Dropdown.Panel>
+                                <Dropdown.Item onSelect={handlePickBlankEvent}>
+                                    <FilePlus2 className="size-4" />
+                                    Blank event
+                                </Dropdown.Item>
+                                {eventTemplates.length > 0 && <Dropdown.Separator />}
                                 {eventTemplates.map((event) => (
-                                    <Dropdown.Item key={event.id} onSelect={() => void handleCreateInstance(event)}>
+                                    <Dropdown.Item key={event.id} onSelect={() => handlePickEventTemplate(event)}>
                                         {event.title}
                                     </Dropdown.Item>
                                 ))}
@@ -113,8 +160,8 @@ export function CueSheetOverviewScreen() {
                     <Card.Content ghost className="flex flex-col gap-1.5">
                         {isLoadingEvents ? (
                             <div className="flex justify-center py-6"><Spinner /></div>
-                        ) : eventInstances.length > 0 ? (
-                            eventInstances.map((event) => (
+                        ) : overviewEventRuns.length > 0 ? (
+                            overviewEventRuns.map((event) => (
                                 <EventItem key={event.id} event={event} />
                             ))
                         ) : (
@@ -139,8 +186,13 @@ export function CueSheetOverviewScreen() {
                                 <Button.Icon variant="secondary" icon={<Plus />} />
                             </Dropdown.Trigger>
                             <Dropdown.Panel>
+                                <Dropdown.Item onSelect={handlePickBlankChecklist}>
+                                    <FilePlus2 className="size-4" />
+                                    Blank checklist
+                                </Dropdown.Item>
+                                {checklistTemplates.length > 0 && <Dropdown.Separator />}
                                 {checklistTemplates.map((checklist) => (
-                                    <Dropdown.Item key={checklist.id} onSelect={() => void handleCreateChecklistRun(checklist)}>
+                                    <Dropdown.Item key={checklist.id} onSelect={() => handlePickChecklistTemplate(checklist)}>
                                         {checklist.name}
                                     </Dropdown.Item>
                                 ))}
@@ -155,8 +207,8 @@ export function CueSheetOverviewScreen() {
                     <Card.Content ghost className="flex flex-col gap-1.5">
                         {isLoadingChecklists ? (
                             <div className="flex justify-center py-6"><Spinner /></div>
-                        ) : checklistInstances.length > 0 ? (
-                            checklistInstances.map((checklist) => (
+                        ) : overviewChecklistRuns.length > 0 ? (
+                            overviewChecklistRuns.map((checklist) => (
                                 <ChecklistItemCard key={checklist.id} checklist={checklist} />
                             ))
                         ) : (
@@ -170,6 +222,8 @@ export function CueSheetOverviewScreen() {
                 </Card.Root>
             </div>
 
+            <CreateEventRunModal open={eventModalOpen} onOpenChange={setEventModalOpen} template={eventModalTemplate} onSubmit={handleEventSubmit} />
+            <CreateChecklistRunModal open={checklistModalOpen} onOpenChange={setChecklistModalOpen} template={checklistModalTemplate} onSubmit={handleChecklistSubmit} />
         </section>
     )
 }

--- a/src/screens/equipment/booking/page.tsx
+++ b/src/screens/equipment/booking/page.tsx
@@ -15,8 +15,13 @@ import { BookingDrawer } from "@/features/equipment/booking-drawer";
 import { useBookingFilters } from "@/features/equipment/use-booking-filters";
 import { BookingFilterDrawer } from "@/features/equipment/booking-filter-drawer";
 import { BookingCalendar } from "@/features/equipment/booking-calendar";
+import { CreateBookingModal } from "@/features/equipment/create-booking-modal";
 import { bookingStatusLabel, bookingStatusColor } from "@/types/equipment";
 import type { Booking, Equipment } from "@/types/equipment";
+import { createBooking } from "@/data/mutate-booking";
+import { fetchEquipmentById } from "@/data/fetch-equipment";
+import { useFeedback } from "@/components/feedback/feedback-provider";
+import { getErrorMessage } from "@/utils/get-error-message";
 import { formatUtcIsoInBrowserTimeZone } from "@/utils/browser-date-time";
 
 const columns = [
@@ -55,8 +60,9 @@ const columns = [
 export function EquipmentBookingsScreen() {
   const {
     state: { bookings, isLoadingBookings, equipment, isLoadingEquipment },
-    actions: { loadBookings, loadEquipment },
+    actions: { loadBookings, loadEquipment, syncBooking, syncEquipment },
   } = useEquipment();
+  const { toast } = useFeedback();
 
   useEffect(() => {
     loadBookings();
@@ -65,6 +71,7 @@ export function EquipmentBookingsScreen() {
 
   const [view, setView] = useState("table");
   const [selectedBooking, setSelectedBooking] = useState<Booking | null>(null);
+  const [createOpen, setCreateOpen] = useState(false);
   const isDirtyRef = useRef(false);
   const requestCloseRef = useRef<(() => void) | null>(null);
 
@@ -95,6 +102,22 @@ export function EquipmentBookingsScreen() {
 
   const isLoading = isLoadingBookings || isLoadingEquipment;
 
+  const handleCreateBooking = useCallback(async (params: { equipmentId: string; equipmentName: string; bookedBy: string; checkedOutDate: string; expectedReturnAt: string; notes: string; status: Booking["status"] }) => {
+    try {
+      const savedBooking = await createBooking(params);
+      syncBooking(savedBooking);
+      const refreshedEquipment = await fetchEquipmentById(savedBooking.equipmentId);
+      if (refreshedEquipment) {
+        syncEquipment(refreshedEquipment);
+      }
+      toast({ title: "Booking created", variant: "success" });
+    } catch (error) {
+      const message = getErrorMessage(error, "The booking could not be created.");
+      toast({ title: "Failed to create booking", description: message, variant: "error" });
+      throw new Error(message);
+    }
+  }, [syncBooking, syncEquipment, toast]);
+
   return (
     <section>
       <Header.Root className="p-4 pt-8 mx-auto max-w-content">
@@ -116,6 +139,7 @@ export function EquipmentBookingsScreen() {
           </Header.Lead>
           <Header.Trail className="gap-2 flex-1 justify-end">
             <Input icon={<Search />} placeholder="Search bookings..." className="w-full max-w-sm" value={state.search} onChange={(e) => setSearch(e.target.value)} />
+            <Button onClick={() => setCreateOpen(true)}>New Booking</Button>
             <Drawer.Root>
               <Drawer.Trigger>
                 <Button icon={<Settings2 />} variant="secondary">Filter</Button>
@@ -147,6 +171,7 @@ export function EquipmentBookingsScreen() {
           <BookingCalendar bookings={filtered} equipmentMap={equipmentMap} />
         )}
       </div>
+      <CreateBookingModal open={createOpen} onOpenChange={setCreateOpen} equipment={equipment} onCreate={handleCreateBooking} />
     </section>
   );
 }

--- a/src/screens/equipment/detail/page.tsx
+++ b/src/screens/equipment/detail/page.tsx
@@ -64,7 +64,7 @@ export function EquipmentDetailScreen() {
 function EquipmentDetailContent({ equipment }: { equipment: Equipment }) {
   const navigate = useNavigate();
   const { toast } = useFeedback();
-  const { actions: { syncEquipment, removeEquipment } } = useEquipment();
+  const { actions: { syncEquipment, removeEquipment, removeBookingsByEquipmentId } } = useEquipment();
 
   const store = useEquipmentStore(equipment, { syncEquipment });
   const [bookings, setBookings] = useState<Booking[]>([]);
@@ -125,6 +125,7 @@ function EquipmentDetailContent({ equipment }: { equipment: Equipment }) {
     try {
       await deleteEquipment(equipment.id);
       removeEquipment(equipment.id);
+      removeBookingsByEquipmentId(equipment.id);
       toast({ title: "Equipment deleted", variant: "success" });
       setShowDeleteModal(false);
       navigate("/equipment");

--- a/src/screens/public/layout.tsx
+++ b/src/screens/public/layout.tsx
@@ -9,7 +9,7 @@ export function PublicLayout({ children }: { children: ReactNode }) {
         <div className="mx-auto max-w-content-md flex items-center gap-4 px-6 py-4">
           <Link to="/" className="flex items-center gap-2">
             <div className="size-7 rounded-lg bg-brand_solid">
-              <img src="/logo.svg" alt="" className="w-full h-full" />
+              <img src="./logo.svg" alt="" className="w-full h-full" />
             </div>
             <span className="label-md">MOC Console</span>
           </Link>


### PR DESCRIPTION
## Summary
- **Cue sheet**: new event and checklist drawers with editable meta + delete confirmation; "Blank event" / "Blank checklist" entries in the create dropdowns with a shared run-creation modal that captures title/description/scheduled-at (and duration for blank events); shared `run-status` helpers and filter hooks reused across overview and list pages.
- **Equipment**: new create-booking modal, booking and equipment drawer refinements, provider updates.
- **Broadcast / Zoom**: detail and media page polish, OAuth handler updates, stream and meeting mutate flows.
- **Data layer**: refreshed `fetch-*` / `mutate-*` modules for cue sheet, broadcast, streams, zoom, requests, workspaces, assignees; added `phase-10-rpcs.sql` migration for template duplication and structure-save RPCs.

## Test plan
- [ ] Cue sheet overview: open the events `+` and checklists `+` dropdowns; "Blank …" appears at the top above the templates.
- [ ] From a blank pick: modal asks for title/description/scheduled-at (events also show duration); submit creates the run and (for events) navigates to the timeline.
- [ ] From a template pick: modal pre-fills `"<title> Run"` and template description; submit creates the run with the chosen scheduled-at.
- [ ] Click an event row on the overview and on `/cue-sheet/events`: drawer opens with editable title/description and meta (scheduled, duration, tracks); Maximize2 / "Open timeline" navigates to the detail page.
- [ ] Click a checklist row: drawer opens with editable name/description and item content; Maximize2 navigates to the detail page.
- [ ] Trash icon in each drawer opens the danger-confirm modal; confirming deletes the event/checklist and closes the drawer with a toast.
- [ ] Equipment booking: open `+` on bookings page, the new modal creates a booking; verify drawers and provider updates work end-to-end.
- [ ] Broadcast and Zoom flows still load and sync without regressions.
- [ ] Run `phase-10-rpcs.sql` against the target DB before deploy and confirm template duplication + structure-save RPCs resolve from the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)