### PR TITLE
fix: correct zoom v2 proxy import path

### DIFF
--- a/api/zoom/v2/[...path].ts
+++ b/api/zoom/v2/[...path].ts
@@ -1,4 +1,4 @@
-import { proxyZoomApiRequest } from "../../../../server/zoom-api.js"
+import { proxyZoomApiRequest } from "../../../server/zoom-api.js"
 
 type ApiRequest = {
   body?: Buffer | string


### PR DESCRIPTION
## Summary
`api/zoom/v2/[...path].ts` is 3 levels below the repo root; the import used `../../../../server/zoom-api.js` (4 levels). The wrong depth was masked by the prior missing-extension error — once `.js` was added in #15, Vercel's tsc surfaced TS2307 (cannot find module). Trimmed one `../` to match the OAuth handlers.

## Test plan
- [ ] Vercel build for the merge of this PR turns green (no TS2307 on `api/zoom/v2/[...path].ts`).
- [ ] Hit the `/api/zoom/v2/...` proxy in production and confirm Zoom requests still pass through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)