### PR TITLE
feat: capture Telegram groups + forum topics, admin management page

### DIFF
--- a/api/telegram/webhook.ts
+++ b/api/telegram/webhook.ts
@@ -13,19 +13,42 @@ type ApiResponse = {
   setHeader: (name: string, value: string) => void
 }
 
+type TelegramChat = {
+  id?: number | string
+  type?: "private" | "group" | "supergroup" | "channel"
+  title?: string
+  is_forum?: boolean
+}
+
+type TelegramForumTopicCreated = { name?: string }
+type TelegramForumTopicEdited = { name?: string }
+
+type TelegramMessage = {
+  chat?: TelegramChat
+  text?: string
+  from?: { username?: string }
+  message_thread_id?: number
+  forum_topic_created?: TelegramForumTopicCreated
+  forum_topic_edited?: TelegramForumTopicEdited
+  forum_topic_closed?: Record<string, never>
+  forum_topic_reopened?: Record<string, never>
+}
+
+type TelegramChatMemberUpdated = {
+  chat?: TelegramChat
+  new_chat_member?: { status?: string }
+}
+
 type TelegramUpdate = {
   message?: TelegramMessage
   edited_message?: TelegramMessage
-}
-
-type TelegramMessage = {
-  chat?: { id?: number | string }
-  text?: string
-  from?: { username?: string }
+  my_chat_member?: TelegramChatMemberUpdated
 }
 
 const TELEGRAM_API = "https://api.telegram.org"
 const START_COMMAND = /^\/start(?:\s+(\S+))?\s*$/
+const PRESENT_STATUSES = new Set(["member", "administrator", "creator", "restricted"])
+const ABSENT_STATUSES = new Set(["left", "kicked"])
 
 function safeEqual(a: string, b: string): boolean {
   const ab = Buffer.from(a)
@@ -48,6 +71,160 @@ async function sendMessage(chatId: number | string, text: string): Promise<void>
   }
 }
 
+async function handleMyChatMember(update: TelegramChatMemberUpdated): Promise<void> {
+  const chat = update.chat
+  const status = update.new_chat_member?.status
+  if (!chat?.id || !chat.type || !status) return
+  if (chat.type !== "group" && chat.type !== "supergroup") return
+
+  const admin = getSupabaseAdmin()
+  const chatIdStr = String(chat.id)
+
+  if (PRESENT_STATUSES.has(status)) {
+    await admin.from("telegram_groups").upsert(
+      {
+        chat_id: chatIdStr,
+        title: chat.title ?? "",
+        type: chat.type,
+        is_forum: chat.is_forum ?? false,
+        removed_at: null,
+      },
+      { onConflict: "chat_id" },
+    )
+    return
+  }
+
+  if (ABSENT_STATUSES.has(status)) {
+    await admin
+      .from("telegram_groups")
+      .update({ removed_at: new Date().toISOString() })
+      .eq("chat_id", chatIdStr)
+  }
+}
+
+async function handleForumTopicMessage(message: TelegramMessage): Promise<boolean> {
+  const chat = message.chat
+  const threadId = message.message_thread_id
+  if (!chat?.id || typeof threadId !== "number") return false
+
+  const admin = getSupabaseAdmin()
+  const groupChatId = String(chat.id)
+
+  if (message.forum_topic_created) {
+    await admin.from("telegram_group_topics").upsert(
+      {
+        group_chat_id: groupChatId,
+        thread_id: threadId,
+        name: message.forum_topic_created.name ?? "",
+        closed: false,
+      },
+      { onConflict: "group_chat_id,thread_id" },
+    )
+    return true
+  }
+
+  if (message.forum_topic_edited) {
+    const patch: { name?: string } = {}
+    if (typeof message.forum_topic_edited.name === "string") {
+      patch.name = message.forum_topic_edited.name
+    }
+    if (Object.keys(patch).length > 0) {
+      await admin
+        .from("telegram_group_topics")
+        .update(patch)
+        .eq("group_chat_id", groupChatId)
+        .eq("thread_id", threadId)
+    }
+    return true
+  }
+
+  if (message.forum_topic_closed) {
+    await admin
+      .from("telegram_group_topics")
+      .update({ closed: true })
+      .eq("group_chat_id", groupChatId)
+      .eq("thread_id", threadId)
+    return true
+  }
+
+  if (message.forum_topic_reopened) {
+    await admin
+      .from("telegram_group_topics")
+      .update({ closed: false })
+      .eq("group_chat_id", groupChatId)
+      .eq("thread_id", threadId)
+    return true
+  }
+
+  return false
+}
+
+async function handleStartCommand(message: TelegramMessage): Promise<void> {
+  const chatId = message.chat?.id
+  const text = message.text
+  if (chatId === undefined || typeof text !== "string") return
+
+  // Linking is a private-chat flow only — ignore /start in groups.
+  if (message.chat?.type && message.chat.type !== "private") return
+
+  const match = text.match(START_COMMAND)
+  if (!match) return
+
+  const token = match[1]
+
+  if (!token) {
+    await sendMessage(chatId, "Hi! To link your account, open MOC Console, go to your profile, and click \"Link Telegram\".")
+    return
+  }
+
+  const admin = getSupabaseAdmin()
+
+  const { data: row } = await admin
+    .from("telegram_link_tokens")
+    .select("token, user_id, expires_at")
+    .eq("token", token)
+    .maybeSingle()
+
+  if (!row) {
+    await sendMessage(chatId, "That link is invalid or has already been used. Open MOC Console and click \"Link Telegram\" again.")
+    return
+  }
+
+  if (new Date(row.expires_at) < new Date()) {
+    await admin.from("telegram_link_tokens").delete().eq("token", token)
+    await sendMessage(chatId, "That link has expired. Open MOC Console and click \"Link Telegram\" again.")
+    return
+  }
+
+  // Atomic single-use gate: only one concurrent webhook can win the delete.
+  const { data: consumed } = await admin
+    .from("telegram_link_tokens")
+    .delete()
+    .eq("token", token)
+    .select("user_id")
+    .maybeSingle()
+
+  if (!consumed) {
+    await sendMessage(chatId, "That link was already used. Open MOC Console and click \"Link Telegram\" again.")
+    return
+  }
+
+  const chatIdStr = String(chatId)
+  const { error: updateError } = await admin
+    .from("users")
+    .update({ telegram_chat_id: chatIdStr })
+    .eq("id", consumed.user_id)
+
+  if (updateError) {
+    // Most likely a UNIQUE violation: this Telegram chat is already bound to another user.
+    await sendMessage(chatId, "This Telegram account is already linked to another MOC Console user. Unlink it there first.")
+    return
+  }
+
+  const handle = message.from?.username ? `@${message.from.username}` : "your account"
+  await sendMessage(chatId, `Linked! ${handle} will now receive MOC Console notifications here.`)
+}
+
 export default async function handler(request: ApiRequest, response: ApiResponse) {
   response.setHeader("Content-Type", "application/json")
 
@@ -68,79 +245,26 @@ export default async function handler(request: ApiRequest, response: ApiResponse
   // From here on, always return 200 — Telegram retries non-2xx aggressively.
   try {
     const update = (request.body ?? {}) as TelegramUpdate
+
+    if (update.my_chat_member) {
+      await handleMyChatMember(update.my_chat_member)
+      response.status(200).json({ ok: true })
+      return
+    }
+
     const message = update.message ?? update.edited_message
-    const chatId = message?.chat?.id
-    const text = message?.text
-
-    if (!message || chatId === undefined || typeof text !== "string") {
+    if (!message) {
       response.status(200).json({ ok: true })
       return
     }
 
-    const match = text.match(START_COMMAND)
-    if (!match) {
+    const handled = await handleForumTopicMessage(message)
+    if (handled) {
       response.status(200).json({ ok: true })
       return
     }
 
-    const token = match[1]
-
-    if (!token) {
-      await sendMessage(chatId, "Hi! To link your account, open MOC Console, go to your profile, and click \"Link Telegram\".")
-      response.status(200).json({ ok: true })
-      return
-    }
-
-    const admin = getSupabaseAdmin()
-
-    const { data: row } = await admin
-      .from("telegram_link_tokens")
-      .select("token, user_id, expires_at")
-      .eq("token", token)
-      .maybeSingle()
-
-    if (!row) {
-      await sendMessage(chatId, "That link is invalid or has already been used. Open MOC Console and click \"Link Telegram\" again.")
-      response.status(200).json({ ok: true })
-      return
-    }
-
-    if (new Date(row.expires_at) < new Date()) {
-      await admin.from("telegram_link_tokens").delete().eq("token", token)
-      await sendMessage(chatId, "That link has expired. Open MOC Console and click \"Link Telegram\" again.")
-      response.status(200).json({ ok: true })
-      return
-    }
-
-    // Atomic single-use gate: only one concurrent webhook can win the delete.
-    const { data: consumed } = await admin
-      .from("telegram_link_tokens")
-      .delete()
-      .eq("token", token)
-      .select("user_id")
-      .maybeSingle()
-
-    if (!consumed) {
-      await sendMessage(chatId, "That link was already used. Open MOC Console and click \"Link Telegram\" again.")
-      response.status(200).json({ ok: true })
-      return
-    }
-
-    const chatIdStr = String(chatId)
-    const { error: updateError } = await admin
-      .from("users")
-      .update({ telegram_chat_id: chatIdStr })
-      .eq("id", consumed.user_id)
-
-    if (updateError) {
-      // Most likely a UNIQUE violation: this Telegram chat is already bound to another user.
-      await sendMessage(chatId, "This Telegram account is already linked to another MOC Console user. Unlink it there first.")
-      response.status(200).json({ ok: true })
-      return
-    }
-
-    const handle = message.from?.username ? `@${message.from.username}` : "your account"
-    await sendMessage(chatId, `Linked! ${handle} will now receive MOC Console notifications here.`)
+    await handleStartCommand(message)
     response.status(200).json({ ok: true })
   } catch (error) {
     console.error("Telegram webhook error:", error)

--- a/docs/phases/phase-21-telegram-groups.sql
+++ b/docs/phases/phase-21-telegram-groups.sql
@@ -1,0 +1,99 @@
+-- ============================================================
+-- Phase 21 — Telegram Groups & Forum Topics
+-- Requires: Phase 02 (public.users), Phase 08 (private helpers),
+--           Phase 09 (RLS pattern), Phase 20 (Telegram linking)
+-- ============================================================
+-- Captures groups/supergroups the bot has been added to, plus
+-- forum topics (threads) within them, so the app can later send
+-- event-driven notifications to specific groups/topics.
+--
+-- Population is driven by api/telegram/webhook.ts using the
+-- service-role key (bypasses RLS):
+--   - my_chat_member updates upsert/soft-delete telegram_groups
+--   - forum_topic_* service messages upsert telegram_group_topics
+--
+-- Admins (can_manage_roles) read these tables and toggle
+-- telegram_groups.active. Authenticated non-admin users have no
+-- access.
+--
+-- IMPORTANT (operational): re-run setWebhook with my_chat_member
+-- in allowed_updates, e.g.:
+--   curl -X POST "https://api.telegram.org/bot$TOKEN/setWebhook" \
+--     -d url=$URL -d secret_token=$SECRET \
+--     -d 'allowed_updates=["message","edited_message","my_chat_member"]'
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.telegram_groups (
+  chat_id     text        PRIMARY KEY,
+  title       text        NOT NULL,
+  type        text        NOT NULL,
+  is_forum    boolean     NOT NULL DEFAULT false,
+  active      boolean     NOT NULL DEFAULT false,
+  added_at    timestamptz NOT NULL DEFAULT now(),
+  removed_at  timestamptz NULL,
+  updated_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS telegram_groups_active_idx
+  ON public.telegram_groups (active) WHERE removed_at IS NULL;
+
+CREATE TABLE IF NOT EXISTS public.telegram_group_topics (
+  group_chat_id text        NOT NULL REFERENCES public.telegram_groups(chat_id) ON DELETE CASCADE,
+  thread_id     bigint      NOT NULL,
+  name          text        NOT NULL,
+  closed        boolean     NOT NULL DEFAULT false,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (group_chat_id, thread_id)
+);
+
+CREATE INDEX IF NOT EXISTS telegram_group_topics_group_idx
+  ON public.telegram_group_topics (group_chat_id);
+
+-- updated_at triggers
+CREATE OR REPLACE FUNCTION public.set_telegram_groups_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS telegram_groups_set_updated_at ON public.telegram_groups;
+CREATE TRIGGER telegram_groups_set_updated_at
+  BEFORE UPDATE ON public.telegram_groups
+  FOR EACH ROW EXECUTE FUNCTION public.set_telegram_groups_updated_at();
+
+CREATE OR REPLACE FUNCTION public.set_telegram_group_topics_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END $$;
+
+DROP TRIGGER IF EXISTS telegram_group_topics_set_updated_at ON public.telegram_group_topics;
+CREATE TRIGGER telegram_group_topics_set_updated_at
+  BEFORE UPDATE ON public.telegram_group_topics
+  FOR EACH ROW EXECUTE FUNCTION public.set_telegram_group_topics_updated_at();
+
+-- ============================================================
+-- RLS — admin-only read/update; webhook (service role) bypasses
+-- ============================================================
+
+ALTER TABLE public.telegram_groups       ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.telegram_group_topics ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "telegram_groups_select_admin" ON public.telegram_groups;
+CREATE POLICY "telegram_groups_select_admin" ON public.telegram_groups
+  FOR SELECT TO authenticated
+  USING (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "telegram_groups_update_admin" ON public.telegram_groups;
+CREATE POLICY "telegram_groups_update_admin" ON public.telegram_groups
+  FOR UPDATE TO authenticated
+  USING (private.current_user_can('can_manage_roles'))
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "telegram_group_topics_select_admin" ON public.telegram_group_topics;
+CREATE POLICY "telegram_group_topics_select_admin" ON public.telegram_group_topics
+  FOR SELECT TO authenticated
+  USING (private.current_user_can('can_manage_roles'));

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -39,6 +39,7 @@ const CueSheetChecklistScreen = lazy(() => import('./screens/cue-sheet/checklist
 const CueSheetChecklistDetailScreen = lazy(() => import('./screens/cue-sheet/checklist/detail/page').then((m) => ({ default: m.CueSheetChecklistDetailScreen })))
 const CueSheetTemplatesScreen = lazy(() => import('./screens/cue-sheet/templates/page').then((m) => ({ default: m.CueSheetTemplatesScreen })))
 const UsersScreen = lazy(() => import('./screens/users/page').then((m) => ({ default: m.UsersScreen })))
+const TelegramGroupsScreen = lazy(() => import('./screens/admin/telegram-groups/page').then((m) => ({ default: m.TelegramGroupsScreen })))
 const LoginScreen = lazy(() => import('./screens/auth/login').then((m) => ({ default: m.LoginScreen })))
 const SignupScreen = lazy(() => import('./screens/auth/signup').then((m) => ({ default: m.SignupScreen })))
 const ResetPasswordScreen = lazy(() => import('./screens/auth/reset-password').then((m) => ({ default: m.ResetPasswordScreen })))
@@ -131,6 +132,7 @@ const router = createBrowserRouter([
             { index: true, element: <Navigate to={`/${routes.dashboard}`} replace /> },
             { path: routes.dashboard, element: <RequestsProvider><EquipmentProvider><BroadcastProvider><CueSheetProvider><DashboardScreen /></CueSheetProvider></BroadcastProvider></EquipmentProvider></RequestsProvider> },
             { path: routes.users, element: <UsersProvider><UsersScreen /></UsersProvider> },
+            { path: routes.telegramGroups, element: <TelegramGroupsScreen /> },
             { path: routes.profile, element: <ProfileScreen /> },
             { path: routes.settings, element: <SettingsScreen /> },
             {

--- a/src/data/fetch-telegram-groups.ts
+++ b/src/data/fetch-telegram-groups.ts
@@ -1,0 +1,71 @@
+import { supabase } from "@/lib/supabase";
+
+export type TelegramGroupTopic = {
+  threadId: number;
+  name: string;
+  closed: boolean;
+};
+
+export type TelegramGroup = {
+  chatId: string;
+  title: string;
+  type: string;
+  isForum: boolean;
+  active: boolean;
+  addedAt: string;
+  removedAt: string | null;
+  topics: TelegramGroupTopic[];
+};
+
+type GroupRow = {
+  chat_id: string;
+  title: string;
+  type: string;
+  is_forum: boolean;
+  active: boolean;
+  added_at: string;
+  removed_at: string | null;
+  telegram_group_topics: TopicRow[] | null;
+};
+
+type TopicRow = {
+  thread_id: number;
+  name: string;
+  closed: boolean;
+};
+
+/** Fetch all telegram groups the bot has been added to (and not removed from), with their topics. */
+export async function fetchTelegramGroups(): Promise<TelegramGroup[]> {
+  const { data, error } = await supabase
+    .from("telegram_groups")
+    .select(
+      "chat_id, title, type, is_forum, active, added_at, removed_at, telegram_group_topics(thread_id, name, closed)",
+    )
+    .is("removed_at", null)
+    .order("added_at", { ascending: false });
+
+  if (error) throw new Error(error.message);
+
+  return ((data ?? []) as GroupRow[]).map((row) => ({
+    chatId: row.chat_id,
+    title: row.title,
+    type: row.type,
+    isForum: row.is_forum,
+    active: row.active,
+    addedAt: row.added_at,
+    removedAt: row.removed_at,
+    topics: (row.telegram_group_topics ?? [])
+      .map((t) => ({ threadId: t.thread_id, name: t.name, closed: t.closed }))
+      .sort((a, b) => a.threadId - b.threadId),
+  }));
+}
+
+/** Toggle whether a telegram group is active for sending messages. */
+export async function setTelegramGroupActive(chatId: string, active: boolean): Promise<void> {
+  const { error } = await supabase
+    .from("telegram_groups")
+    .update({ active })
+    .eq("chat_id", chatId);
+
+  if (error) throw new Error(error.message);
+}

--- a/src/features/app-shell.tsx
+++ b/src/features/app-shell.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react'
 import { routes } from '@/screens/console-routes'
 import { Sidebar } from '../components/navigation/sidebar'
 import { Breadcrumb } from '../components/navigation/breadcrumb'
-import { Cast, Drama, FileText, LayoutGrid, Package, Users } from 'lucide-react'
+import { Cast, Drama, FileText, LayoutGrid, MessagesSquare, Package, Users } from 'lucide-react'
 import { TopBar } from './topbar'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { useSidebar } from '../components/navigation/sidebar'
@@ -73,6 +73,9 @@ export function AppShell({ children }: { children: React.ReactNode }) {
                                 <Sidebar.MenuItem title={"Dashboard"} icon={<LayoutGrid />} active={isActive(routes.dashboard)} onClick={() => navigateToRoute(routes.dashboard)} />
                                 {role?.can_manage_roles && (
                                     <Sidebar.MenuItem title={"Users"} icon={<Users />} active={isActive(routes.users)} onClick={() => navigateToRoute(routes.users)} />
+                                )}
+                                {role?.can_manage_roles && (
+                                    <Sidebar.MenuItem title={"Telegram Groups"} icon={<MessagesSquare />} active={isActive(routes.telegramGroups)} onClick={() => navigateToRoute(routes.telegramGroups)} />
                                 )}
                                 <SearchMenuItem />
                             </Sidebar.GroupContent>

--- a/src/screens/admin/telegram-groups/page.tsx
+++ b/src/screens/admin/telegram-groups/page.tsx
@@ -1,0 +1,141 @@
+import { Badge } from "@/components/display/badge";
+import { Card } from "@/components/display/card";
+import { Header } from "@/components/display/header";
+import { Paragraph, Title, Label } from "@/components/display/text";
+import { Checkbox } from "@/components/form/checkbox";
+import { Spinner } from "@/components/feedback/spinner";
+import { EmptyState } from "@/components/feedback/empty-state";
+import { useFeedback } from "@/components/feedback/feedback-provider";
+import { useAuth } from "@/lib/auth-context";
+import {
+    fetchTelegramGroups,
+    setTelegramGroupActive,
+    type TelegramGroup,
+} from "@/data/fetch-telegram-groups";
+import { MessagesSquare } from "lucide-react";
+import { useCallback, useEffect, useState, type ChangeEvent } from "react";
+import { Navigate } from "react-router-dom";
+import { routes } from "@/screens/console-routes";
+
+export function TelegramGroupsScreen() {
+    const { role } = useAuth();
+    const { toast } = useFeedback();
+
+    const [groups, setGroups] = useState<TelegramGroup[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+    const [pendingChatId, setPendingChatId] = useState<string | null>(null);
+
+    const loadGroups = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const data = await fetchTelegramGroups();
+            setGroups(data);
+        } catch (error) {
+            toast({
+                title: "Couldn't load Telegram groups",
+                description: error instanceof Error ? error.message : "Unknown error",
+                variant: "error",
+            });
+        } finally {
+            setIsLoading(false);
+        }
+    }, [toast]);
+
+    useEffect(() => {
+        void loadGroups();
+    }, [loadGroups]);
+
+    const handleToggleActive = useCallback(
+        async (chatId: string, event: ChangeEvent<HTMLInputElement>) => {
+            const next = event.target.checked;
+            setPendingChatId(chatId);
+            // optimistic
+            setGroups((prev) => prev.map((g) => (g.chatId === chatId ? { ...g, active: next } : g)));
+            try {
+                await setTelegramGroupActive(chatId, next);
+            } catch (error) {
+                // rollback
+                setGroups((prev) => prev.map((g) => (g.chatId === chatId ? { ...g, active: !next } : g)));
+                toast({
+                    title: "Couldn't update group",
+                    description: error instanceof Error ? error.message : "Unknown error",
+                    variant: "error",
+                });
+            } finally {
+                setPendingChatId(null);
+            }
+        },
+        [toast],
+    );
+
+    if (!role?.can_manage_roles && role !== null) {
+        return <Navigate to={`/${routes.dashboard}`} replace />;
+    }
+
+    return (
+        <section>
+            <Header.Root className="p-4 pt-8 mx-auto max-w-content">
+                <Header.Lead className="gap-2">
+                    <Title.h6>Telegram Groups</Title.h6>
+                    <Paragraph.sm className="text-tertiary max-w-2xl">
+                        Groups the bot has been added to. Toggle a group active to allow the app to send event notifications there. Forum topics are listed under each group.
+                    </Paragraph.sm>
+                </Header.Lead>
+            </Header.Root>
+
+            <div className="flex flex-col gap-4 p-4 mx-auto w-full max-w-content">
+                {isLoading ? (
+                    <div className="flex justify-center py-16">
+                        <Spinner size="lg" />
+                    </div>
+                ) : groups.length === 0 ? (
+                    <EmptyState
+                        icon={<MessagesSquare />}
+                        title="No groups yet"
+                        description="Add the bot to a Telegram group or supergroup. It will appear here automatically."
+                    />
+                ) : (
+                    groups.map((group) => (
+                        <Card.Root key={group.chatId}>
+                            <Card.Header>
+                                <div className="flex flex-1 flex-col gap-1">
+                                    <div className="flex items-center gap-2">
+                                        <Label.md>{group.title || "(untitled)"}</Label.md>
+                                        <Badge label={group.type} color="gray" variant="outline" />
+                                        {group.isForum && <Badge label="forum" color="purple" />}
+                                    </div>
+                                    <Paragraph.xs className="text-quaternary">
+                                        chat id {group.chatId}
+                                    </Paragraph.xs>
+                                </div>
+                                <Checkbox
+                                    checked={group.active}
+                                    disabled={pendingChatId === group.chatId}
+                                    onChange={(event) => void handleToggleActive(group.chatId, event)}
+                                >
+                                    <Label.sm>Active</Label.sm>
+                                </Checkbox>
+                            </Card.Header>
+                            {group.topics.length > 0 && (
+                                <Card.Content className="flex flex-col">
+                                    {group.topics.map((topic) => (
+                                        <div
+                                            key={topic.threadId}
+                                            className="flex items-center justify-between px-3 py-2 border-b border-tertiary last:border-b-0"
+                                        >
+                                            <div className="flex items-center gap-2">
+                                                <Label.sm>{topic.name || "(unnamed)"}</Label.sm>
+                                                <Paragraph.xs className="text-quaternary">#{topic.threadId}</Paragraph.xs>
+                                            </div>
+                                            {topic.closed && <Badge label="closed" color="gray" variant="outline" />}
+                                        </div>
+                                    ))}
+                                </Card.Content>
+                            )}
+                        </Card.Root>
+                    ))
+                )}
+            </div>
+        </section>
+    );
+}

--- a/src/screens/console-routes.ts
+++ b/src/screens/console-routes.ts
@@ -5,6 +5,7 @@ export const routes = {
     passwordRecovery: 'password-recovery',
     dashboard: 'dashboard',
     users: 'users',
+    telegramGroups: 'admin/telegram-groups',
     requestsOverview: 'requests',
     requestsAllRequests: 'requests/all-requests',
     requestsArchived: 'requests/archived',


### PR DESCRIPTION
## Summary
- Webhook now handles `my_chat_member` (auto-register groups when bot is added; soft-delete on kick/leave) and `forum_topic_*` service messages so subtopics are captured.
- New `telegram_groups` and `telegram_group_topics` tables (Phase 21 migration), admin-only RLS via `private.current_user_can('can_manage_roles')`. Webhook bypasses with the service-role key.
- New `/admin/telegram-groups` admin screen with per-group `active` toggle and inline topic listing; sidebar entry gated by `can_manage_roles`.
- `/start` linking flow tightened to private chats only so groups don't consume linking tokens.

> Note: this PR rolls up the broader `dev` branch into `main`. The headline change is the Telegram group/topic capture above.

## Operational step before this works in prod
Re-run `setWebhook` with `my_chat_member` in `allowed_updates` (it is **not** included by default):

```sh
curl -X POST "https://api.telegram.org/bot$TOKEN/setWebhook" \
  -d url=$URL -d secret_token=$SECRET \
  -d 'allowed_updates=["message","edited_message","my_chat_member"]'
```

Apply `docs/phases/phase-21-telegram-groups.sql` to Supabase.

## Test plan
- [ ] Apply phase-21 migration; confirm `telegram_groups` + `telegram_group_topics` exist with RLS enabled.
- [ ] Re-register webhook with updated `allowed_updates`.
- [ ] Add the bot to a test supergroup with Topics enabled → row appears in `telegram_groups` (`is_forum=true`, `removed_at` null).
- [ ] Create a topic → row in `telegram_group_topics`. Rename → name updates. Close → `closed=true`. Reopen → `closed=false`.
- [ ] Remove the bot → `removed_at` populated.
- [ ] `/start <token>` from a private DM still links the user (linking flow regression check).
- [ ] `/start` in a group is ignored (no token consumed).
- [ ] Log in as admin → `/admin/telegram-groups` lists the group + topics; toggle `active` persists.
- [ ] Log in as non-admin → redirected to dashboard; sidebar entry hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)