### PR TITLE
feat: capture forum topics from bot mentions in groups

### DIFF
--- a/api/telegram/webhook.ts
+++ b/api/telegram/webhook.ts
@@ -159,6 +159,42 @@ async function handleForumTopicMessage(message: TelegramMessage): Promise<boolea
   return false
 }
 
+// Captures topics that existed before the bot was added (or any topic whose
+// `forum_topic_created` we missed). Inserts a placeholder row keyed by
+// thread_id; never overwrites a row that already has a real name.
+async function handleGroupTopicHint(message: TelegramMessage): Promise<void> {
+  const chat = message.chat
+  const threadId = message.message_thread_id
+  if (typeof threadId !== "number") return
+  if (!chat?.id) return
+  if (chat.type !== "group" && chat.type !== "supergroup") return
+
+  const admin = getSupabaseAdmin()
+  const groupChatId = String(chat.id)
+
+  // Defensive: ensure the group row exists if it predates my_chat_member tracking.
+  await admin.from("telegram_groups").upsert(
+    {
+      chat_id: groupChatId,
+      title: chat.title ?? "",
+      type: chat.type,
+      is_forum: chat.is_forum ?? true,
+      removed_at: null,
+    },
+    { onConflict: "chat_id", ignoreDuplicates: true },
+  )
+
+  await admin.from("telegram_group_topics").upsert(
+    {
+      group_chat_id: groupChatId,
+      thread_id: threadId,
+      name: `Topic #${threadId}`,
+      closed: false,
+    },
+    { onConflict: "group_chat_id,thread_id", ignoreDuplicates: true },
+  )
+}
+
 async function handleStartCommand(message: TelegramMessage): Promise<void> {
   const chatId = message.chat?.id
   const text = message.text
@@ -264,6 +300,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
       return
     }
 
+    await handleGroupTopicHint(message)
     await handleStartCommand(message)
     response.status(200).json({ ok: true })
   } catch (error) {


### PR DESCRIPTION
## Summary
- Captures pre-existing forum topics by @mention. When a non-service message arrives in a group/supergroup with a `message_thread_id` the webhook hasn't seen, a placeholder topic row (`Topic #<id>`) is upserted.
- Uses `ignoreDuplicates: true` so a real name from `forum_topic_created` / `forum_topic_edited` is never overwritten.
- Defensively upserts the group row too, in case the bot was added before `my_chat_member` tracking landed.

## Why
Telegram doesn't expose a "list topics" endpoint, and `forum_topic_created` is only delivered for topics created **after** the bot joins. With privacy mode on (default), the bot only sees commands, replies, mentions, and service messages — so an admin @mentioning the bot in each existing topic is the simplest backfill mechanism.

## Test plan
- [ ] Add bot to a forum supergroup that already has topics.
- [ ] In an existing topic, post `@yourbot ping`. Confirm `telegram_group_topics` gets a row with `name = "Topic #<id>"`.
- [ ] Rename the topic in Telegram → name updates via `forum_topic_edited`.
- [ ] Mention the bot a second time in the same topic → name is **not** overwritten back to placeholder.
- [ ] Create a new topic → still captured immediately via `forum_topic_created` with the real name.
- [ ] Mention bot in a private DM → no group/topic side effects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)