### PR TITLE
feat: /register_topic resolves real Telegram topic name

### DIFF
--- a/api/telegram/webhook.ts
+++ b/api/telegram/webhook.ts
@@ -24,10 +24,12 @@ type TelegramForumTopicCreated = { name?: string }
 type TelegramForumTopicEdited = { name?: string }
 
 type TelegramMessage = {
+  message_id?: number
   chat?: TelegramChat
   text?: string
   from?: { username?: string }
   message_thread_id?: number
+  reply_to_message?: TelegramMessage
   forum_topic_created?: TelegramForumTopicCreated
   forum_topic_edited?: TelegramForumTopicEdited
   forum_topic_closed?: Record<string, never>
@@ -46,7 +48,8 @@ type TelegramUpdate = {
 }
 
 const TELEGRAM_API = "https://api.telegram.org"
-const START_COMMAND = /^\/start(?:\s+(\S+))?\s*$/
+const START_COMMAND = /^\/start(?:@\w+)?(?:\s+(\S+))?\s*$/
+const REGISTER_TOPIC_COMMAND = /^\/register_topic(?:@\w+)?(?:\s+(.+))?\s*$/
 const PRESENT_STATUSES = new Set(["member", "administrator", "creator", "restricted"])
 const ABSENT_STATUSES = new Set(["left", "kicked"])
 
@@ -57,17 +60,55 @@ function safeEqual(a: string, b: string): boolean {
   return timingSafeEqual(ab, bb)
 }
 
-async function sendMessage(chatId: number | string, text: string): Promise<void> {
+type SendMessageOptions = {
+  threadId?: number
+  replyToMessageId?: number
+}
+
+async function sendMessage(
+  chatId: number | string,
+  text: string,
+  options: SendMessageOptions = {},
+): Promise<TelegramMessage | null> {
+  const token = process.env.TELEGRAM_BOT_TOKEN
+  if (!token) return null
+  try {
+    const body: Record<string, unknown> = { chat_id: chatId, text }
+    if (typeof options.threadId === "number") body.message_thread_id = options.threadId
+    if (typeof options.replyToMessageId === "number") {
+      body.reply_parameters = {
+        message_id: options.replyToMessageId,
+        allow_sending_without_reply: true,
+      }
+    }
+    const res = await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    })
+    const json = (await res.json()) as { ok?: boolean; result?: TelegramMessage }
+    return json.ok ? json.result ?? null : null
+  } catch {
+    // Telegram already received its 200; failure to reply is non-fatal.
+    return null
+  }
+}
+
+async function editMessageText(
+  chatId: number | string,
+  messageId: number,
+  text: string,
+): Promise<void> {
   const token = process.env.TELEGRAM_BOT_TOKEN
   if (!token) return
   try {
-    await fetch(`${TELEGRAM_API}/bot${token}/sendMessage`, {
+    await fetch(`${TELEGRAM_API}/bot${token}/editMessageText`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ chat_id: chatId, text }),
+      body: JSON.stringify({ chat_id: chatId, message_id: messageId, text }),
     })
   } catch {
-    // Telegram already received its 200; failure to reply is non-fatal.
+    // non-fatal
   }
 }
 
@@ -159,20 +200,39 @@ async function handleForumTopicMessage(message: TelegramMessage): Promise<boolea
   return false
 }
 
-// Captures topics that existed before the bot was added (or any topic whose
-// `forum_topic_created` we missed). Inserts a placeholder row keyed by
-// thread_id; never overwrites a row that already has a real name.
-async function handleGroupTopicHint(message: TelegramMessage): Promise<void> {
+// `/register_topic` — explicit registration of the topic the command was sent in.
+// Slash commands always reach the bot regardless of privacy mode, so this is the
+// reliable way to capture pre-existing topics.
+//
+// Name resolution: the Telegram Bot API has no method to look up a topic's name.
+// The trick: the topic root message id == message_thread_id, and that root is
+// always a `forum_topic_created` service message. By replying to it we coax
+// Telegram into returning that service message in the response's
+// `reply_to_message`, which carries the real topic name.
+async function handleRegisterTopicCommand(message: TelegramMessage): Promise<boolean> {
+  const text = message.text
+  if (typeof text !== "string") return false
+  if (!REGISTER_TOPIC_COMMAND.test(text)) return false
+
   const chat = message.chat
+  const chatId = chat?.id
+  if (chatId === undefined) return true
+
+  if (chat?.type !== "group" && chat?.type !== "supergroup") {
+    await sendMessage(chatId, "Use /register_topic inside a Telegram group, in the topic you want to register.")
+    return true
+  }
+
   const threadId = message.message_thread_id
-  if (typeof threadId !== "number") return
-  if (!chat?.id) return
-  if (chat.type !== "group" && chat.type !== "supergroup") return
+  if (typeof threadId !== "number") {
+    await sendMessage(chatId, "Run /register_topic from inside a forum topic. Messages sent without a topic id go to General.")
+    return true
+  }
 
+  const groupChatId = String(chatId)
   const admin = getSupabaseAdmin()
-  const groupChatId = String(chat.id)
 
-  // Defensive: ensure the group row exists if it predates my_chat_member tracking.
+  // Defensive group upsert (covers bot-already-in-group case).
   await admin.from("telegram_groups").upsert(
     {
       chat_id: groupChatId,
@@ -184,15 +244,32 @@ async function handleGroupTopicHint(message: TelegramMessage): Promise<void> {
     { onConflict: "chat_id", ignoreDuplicates: true },
   )
 
+  // Reply to the topic root to fetch the real topic name from Telegram.
+  const sent = await sendMessage(chatId, "Registering topic…", {
+    threadId,
+    replyToMessageId: threadId,
+  })
+
+  const resolvedName = sent?.reply_to_message?.forum_topic_created?.name?.trim()
+
   await admin.from("telegram_group_topics").upsert(
     {
       group_chat_id: groupChatId,
       thread_id: threadId,
-      name: `Topic #${threadId}`,
+      name: resolvedName || `Topic #${threadId}`,
       closed: false,
     },
-    { onConflict: "group_chat_id,thread_id", ignoreDuplicates: true },
+    { onConflict: "group_chat_id,thread_id" },
   )
+
+  if (sent?.message_id !== undefined) {
+    const finalText = resolvedName
+      ? `✅ Registered "${resolvedName}".`
+      : `✅ Registered topic #${threadId}. (Couldn't read the topic name from Telegram — rename it in Telegram and I'll pick it up.)`
+    await editMessageText(chatId, sent.message_id, finalText)
+  }
+
+  return true
 }
 
 async function handleStartCommand(message: TelegramMessage): Promise<void> {
@@ -300,7 +377,12 @@ export default async function handler(request: ApiRequest, response: ApiResponse
       return
     }
 
-    await handleGroupTopicHint(message)
+    const registered = await handleRegisterTopicCommand(message)
+    if (registered) {
+      response.status(200).json({ ok: true })
+      return
+    }
+
     await handleStartCommand(message)
     response.status(200).json({ ok: true })
   } catch (error) {


### PR DESCRIPTION
## Summary
- New \`/register_topic\` command. Sent inside a forum topic, it registers that topic in Supabase **with the actual Telegram topic name** (no manual entry, no placeholder).
- Slash commands always reach the bot regardless of privacy mode, so this works even when @mentions don't propagate due to cached per-group privacy state.
- Bot replies in-topic with \`Registering topic…\` then edits the message to \`✅ Registered "<name>".\` once the name resolves.

## How the name is fetched
The Telegram Bot API doesn't expose a method to read a topic's name. Workaround: the topic root message id always equals \`message_thread_id\`, and that root is always a \`forum_topic_created\` service message. By calling \`sendMessage\` with \`reply_parameters.message_id = thread_id\`, Telegram's response includes \`reply_to_message\` — which is that service message — and it carries \`forum_topic_created.name\`. We extract the name and persist it.

If the response somehow doesn't carry a name (e.g. very old topic with no creation service message preserved), we fall back to \`Topic #<id>\` and tell the user to rename the topic in Telegram so \`forum_topic_edited\` picks it up.

## What's not in this PR
The previous draft of this branch had an editable-name UI and a phase-22 migration adding admin UPDATE to \`telegram_group_topics\`. Both removed — the bot pulls the real name itself, so admins don't need to type it.

The placeholder \`handleGroupTopicHint\` (capture-on-@mention) is also removed; \`/register_topic\` is the single canonical registration path.

## Test plan
- [ ] Deploy. In a forum topic, send \`/register_topic\` → bot's status message becomes \`✅ Registered "<topic name>"\`; admin page shows the real name.
- [ ] Send \`/register_topic\` again in the same topic after renaming it in Telegram → name updates (also still updates via \`forum_topic_edited\`).
- [ ] In a topic that pre-existed before the bot joined, \`/register_topic\` still resolves the real name.
- [ ] \`/register_topic\` in General → bot replies "Run /register_topic from inside a forum topic.".
- [ ] \`/register_topic\` in private DM → bot replies "Use /register_topic inside a Telegram group…".
- [ ] \`/start <token>\` from a private DM still works (linking flow unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)