### PR TITLE
fix: improve Android PWA edge-to-edge support

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -184,8 +184,9 @@ export default defineConfig(({ mode }) => {
           start_url: '/',
           scope: '/',
           display: 'standalone',
+          display_override: ['standalone', 'minimal-ui'],
           orientation: 'any',
-          theme_color: '#ffffff',
+          theme_color: '#000000',
           background_color: '#ffffff',
           icons: [
             { src: '/icons/icon-192.png', sizes: '192x192', type: 'image/png', purpose: 'any' },


### PR DESCRIPTION
## Summary
- Add `display_override: ['standalone', 'minimal-ui']` to make the PWA display fallback chain explicit
- Change manifest `theme_color` from `#ffffff` to `#000000` so the system bar tint blends with dark mode (and stays inert behind transparent bars on Chrome 135+)

The app already had `viewport-fit=cover` and `env(safe-area-inset-*)` usage in the topbar/sidebar, so the only missing pieces were the manifest tweaks above.

## Test plan
- [ ] Build and deploy
- [ ] **Uninstall** the existing PWA on an Android device, then reinstall from Chrome's install prompt (required to regenerate the WebAPK — manifest changes won't apply otherwise)
- [ ] Confirm Chrome on the device is 135+ (required for transparent system bars in installed standalone PWAs)
- [ ] Verify content draws behind the gesture nav bar and status bar (no white bars)
- [ ] Verify topbar/sidebar still respect safe-area insets correctly
- [ ] Verify dark mode looks correct (no flash of white at the status bar area)
- [ ] iOS PWA still launches and renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)