### PR TITLE
feat(notifications): event routing to Telegram groups + topics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,9 @@ TELEGRAM_WEBHOOK_SECRET=
 # (e.g. https://moc-console.example.com). Server-only — do NOT VITE_-prefix.
 # When unset, falls back to https://$VERCEL_URL.
 APP_BASE_URL=
+
+# Shared HMAC secret used by external apps (requests/bookings) to sign their
+# POSTs to /api/notifications/requests and /api/notifications/bookings.
+# Sender computes hex(HMAC-SHA256(secret, JSON.stringify(body))) and sends it
+# in the X-Signature header. Server-only.
+NOTIFICATIONS_INGEST_SECRET=

--- a/api/notifications/assignment.ts
+++ b/api/notifications/assignment.ts
@@ -42,8 +42,35 @@ function resolveBaseUrl(): string | null {
   return null
 }
 
-function dutyClause(duty: string): string {
-  return duty ? ` as ${duty}` : ""
+// Telegram's HTML parser only special-cases &, <, > — quotes don't need escaping.
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+function buildMessage(args: {
+  heading: string
+  title: string
+  context?: { label: string; value: string }
+  duty: string
+  linkUrl: string
+  linkLabel: string
+}): string {
+  const lines: string[] = []
+  lines.push(`<b>${args.heading}</b>`)
+  lines.push("")
+  lines.push(escapeHtml(args.title))
+  if (args.context) {
+    lines.push(`${args.context.label}: ${escapeHtml(args.context.value)}`)
+  }
+  if (args.duty) {
+    lines.push(`Duty: <i>${escapeHtml(args.duty)}</i>`)
+  }
+  lines.push("")
+  lines.push(`<a href="${args.linkUrl}">${args.linkLabel}</a>`)
+  return lines.join("\n")
 }
 
 async function buildRequestMessage(
@@ -58,8 +85,13 @@ async function buildRequestMessage(
     .eq("id", parentId)
     .maybeSingle()
   if (!data) return null
-  const link = `${baseUrl}/requests/${parentId}`
-  return `You've been assigned to request "${data.title}"${dutyClause(duty)}.\n${link}`
+  return buildMessage({
+    heading: "You've been assigned to a request",
+    title: data.title,
+    duty,
+    linkUrl: `${baseUrl}/requests/${parentId}`,
+    linkLabel: "Open request",
+  })
 }
 
 async function buildCueMessage(
@@ -89,8 +121,14 @@ async function buildCueMessage(
     .maybeSingle()
   if (!event) return null
 
-  const link = `${baseUrl}/cue-sheet/events/${event.id}`
-  return `You've been assigned to cue "${cue.label}" in event "${event.name}"${dutyClause(duty)}.\n${link}`
+  return buildMessage({
+    heading: "You've been assigned to a cue",
+    title: cue.label,
+    context: { label: "Event", value: event.name },
+    duty,
+    linkUrl: `${baseUrl}/cue-sheet/events/${event.id}`,
+    linkLabel: "Open event",
+  })
 }
 
 async function buildChecklistItemMessage(
@@ -113,8 +151,14 @@ async function buildChecklistItemMessage(
     .maybeSingle()
   if (!checklist) return null
 
-  const link = `${baseUrl}/cue-sheet/checklist/${checklist.id}`
-  return `You've been assigned to checklist item "${item.label}" in "${checklist.name}"${dutyClause(duty)}.\n${link}`
+  return buildMessage({
+    heading: "You've been assigned to a checklist item",
+    title: item.label,
+    context: { label: "Checklist", value: checklist.name },
+    duty,
+    linkUrl: `${baseUrl}/cue-sheet/checklist/${checklist.id}`,
+    linkLabel: "Open checklist",
+  })
 }
 
 export default async function handler(request: ApiRequest, response: ApiResponse) {
@@ -195,6 +239,9 @@ export default async function handler(request: ApiRequest, response: ApiResponse
     return
   }
 
-  await sendTelegramMessage(user.telegram_chat_id, text)
+  await sendTelegramMessage(user.telegram_chat_id, text, {
+    parseMode: "HTML",
+    disableLinkPreview: true,
+  })
   response.status(200).json({ ok: true })
 }

--- a/api/notifications/bookings.ts
+++ b/api/notifications/bookings.ts
@@ -1,0 +1,112 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+import { dispatchEvent } from "../../server/notifications/dispatch.js"
+import { isNotificationEventKey } from "../../src/data/notification-events.js"
+
+type ApiRequest = {
+  method?: string
+  body?: unknown
+  headers?: Record<string, string | string[] | undefined>
+}
+
+type ApiResponse = {
+  status: (code: number) => ApiResponse
+  json: (body: unknown) => void
+  setHeader: (name: string, value: string) => void
+}
+
+type BookingEventType = "booking.created" | "booking.status_changed"
+
+type Body = {
+  event_type?: string
+  workspace_id?: string
+  title?: string
+  status?: string | null
+  requester_name?: string | null
+  link_url?: string
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined> | undefined,
+  name: string,
+): string | null {
+  if (!headers) return null
+  const raw = headers[name] ?? headers[name.toLowerCase()]
+  if (!raw) return null
+  return Array.isArray(raw) ? raw[0] ?? null : raw
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  if (ab.length !== bb.length) return false
+  return timingSafeEqual(ab, bb)
+}
+
+// See api/notifications/requests.ts for the signing contract.
+function verifySignature(body: unknown, provided: string | null): boolean {
+  const secret = process.env.NOTIFICATIONS_INGEST_SECRET
+  if (!secret || !provided) return false
+  const expected = createHmac("sha256", secret)
+    .update(JSON.stringify(body ?? {}))
+    .digest("hex")
+  return safeEqual(expected, provided)
+}
+
+export default async function handler(request: ApiRequest, response: ApiResponse) {
+  response.setHeader("Content-Type", "application/json")
+
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Method not allowed" })
+    return
+  }
+
+  if (!verifySignature(request.body, headerValue(request.headers, "x-signature"))) {
+    response.status(401).json({ error: "Invalid signature" })
+    return
+  }
+
+  const body = (request.body ?? {}) as Body
+  const { event_type, workspace_id, title, link_url } = body
+
+  if (
+    typeof event_type !== "string" ||
+    typeof workspace_id !== "string" || !workspace_id ||
+    typeof title !== "string" || !title ||
+    typeof link_url !== "string" || !link_url
+  ) {
+    response.status(400).json({ error: "Missing fields" })
+    return
+  }
+
+  if (
+    !isNotificationEventKey(event_type) ||
+    (event_type !== "booking.created" && event_type !== "booking.status_changed")
+  ) {
+    response.status(400).json({ error: "Unsupported event_type" })
+    return
+  }
+
+  const requesterName = typeof body.requester_name === "string" ? body.requester_name : null
+
+  let result: { attempted: number; succeeded: number }
+  if (event_type === "booking.status_changed") {
+    if (typeof body.status !== "string" || !body.status) {
+      response.status(400).json({ error: "status required for booking.status_changed" })
+      return
+    }
+    result = await dispatchEvent(workspace_id, event_type as BookingEventType, {
+      title,
+      status: body.status,
+      linkUrl: link_url,
+    })
+  } else {
+    result = await dispatchEvent(workspace_id, "booking.created", {
+      title,
+      status: typeof body.status === "string" ? body.status : null,
+      requesterName,
+      linkUrl: link_url,
+    })
+  }
+
+  response.status(200).json({ ok: true, ...result })
+}

--- a/api/notifications/internal/meeting-created.ts
+++ b/api/notifications/internal/meeting-created.ts
@@ -1,0 +1,85 @@
+import { getSupabaseAdmin } from "../../../server/supabase-admin.js"
+import { dispatchEvent } from "../../../server/notifications/dispatch.js"
+import { requireAuthenticatedUser, AuthError } from "../../../server/auth-guard.js"
+
+type ApiRequest = {
+  method?: string
+  body?: unknown
+  headers?: Record<string, string | string[] | undefined>
+}
+
+type ApiResponse = {
+  status: (code: number) => ApiResponse
+  json: (body: unknown) => void
+  setHeader: (name: string, value: string) => void
+}
+
+type Body = { meetingId?: string }
+
+function normaliseHeaders(
+  headers: Record<string, string | string[] | undefined> | undefined,
+): Record<string, string | undefined> {
+  if (!headers) return {}
+  const out: Record<string, string | undefined> = {}
+  for (const [name, value] of Object.entries(headers)) {
+    out[name] = Array.isArray(value) ? value[0] : value
+  }
+  return out
+}
+
+export default async function handler(request: ApiRequest, response: ApiResponse) {
+  response.setHeader("Content-Type", "application/json")
+
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Method not allowed" })
+    return
+  }
+
+  try {
+    await requireAuthenticatedUser(normaliseHeaders(request.headers))
+  } catch (error) {
+    if (error instanceof AuthError) {
+      response.status(401).json({ error: error.message })
+      return
+    }
+    response.status(401).json({ error: "Unauthorized" })
+    return
+  }
+
+  const body = (request.body ?? {}) as Body
+  if (typeof body.meetingId !== "string" || !body.meetingId) {
+    response.status(400).json({ error: "Missing meetingId" })
+    return
+  }
+
+  const admin = getSupabaseAdmin()
+  const { data: claimed } = await admin
+    .from("zoom_meetings")
+    .update({ notified_at: new Date().toISOString() })
+    .eq("id", body.meetingId)
+    .is("notified_at", null)
+    .select("id, workspace_id, topic, start_time, join_url")
+    .maybeSingle()
+
+  if (!claimed) {
+    response.status(200).json({ ok: true, skipped: "already_notified_or_missing" })
+    return
+  }
+
+  type MeetingRow = {
+    id: string
+    workspace_id: string
+    topic: string
+    start_time: string | null
+    join_url: string | null
+  }
+  const row = claimed as MeetingRow
+
+  const result = await dispatchEvent(row.workspace_id, "meeting.created", {
+    topic: row.topic,
+    startTime: row.start_time,
+    joinUrl: row.join_url,
+  })
+
+  response.status(200).json({ ok: true, ...result })
+}

--- a/api/notifications/internal/stream-created.ts
+++ b/api/notifications/internal/stream-created.ts
@@ -1,0 +1,86 @@
+import { getSupabaseAdmin } from "../../../server/supabase-admin.js"
+import { dispatchEvent } from "../../../server/notifications/dispatch.js"
+import { requireAuthenticatedUser, AuthError } from "../../../server/auth-guard.js"
+
+type ApiRequest = {
+  method?: string
+  body?: unknown
+  headers?: Record<string, string | string[] | undefined>
+}
+
+type ApiResponse = {
+  status: (code: number) => ApiResponse
+  json: (body: unknown) => void
+  setHeader: (name: string, value: string) => void
+}
+
+type Body = { streamId?: string }
+
+function normaliseHeaders(
+  headers: Record<string, string | string[] | undefined> | undefined,
+): Record<string, string | undefined> {
+  if (!headers) return {}
+  const out: Record<string, string | undefined> = {}
+  for (const [name, value] of Object.entries(headers)) {
+    out[name] = Array.isArray(value) ? value[0] : value
+  }
+  return out
+}
+
+export default async function handler(request: ApiRequest, response: ApiResponse) {
+  response.setHeader("Content-Type", "application/json")
+
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Method not allowed" })
+    return
+  }
+
+  try {
+    await requireAuthenticatedUser(normaliseHeaders(request.headers))
+  } catch (error) {
+    if (error instanceof AuthError) {
+      response.status(401).json({ error: error.message })
+      return
+    }
+    response.status(401).json({ error: "Unauthorized" })
+    return
+  }
+
+  const body = (request.body ?? {}) as Body
+  if (typeof body.streamId !== "string" || !body.streamId) {
+    response.status(400).json({ error: "Missing streamId" })
+    return
+  }
+
+  // Atomic claim: only the first call where notified_at IS NULL gets a row back.
+  const admin = getSupabaseAdmin()
+  const { data: claimed } = await admin
+    .from("streams")
+    .update({ notified_at: new Date().toISOString() })
+    .eq("id", body.streamId)
+    .is("notified_at", null)
+    .select("id, workspace_id, title, scheduled_start_time, stream_url")
+    .maybeSingle()
+
+  if (!claimed) {
+    response.status(200).json({ ok: true, skipped: "already_notified_or_missing" })
+    return
+  }
+
+  type StreamRow = {
+    id: string
+    workspace_id: string
+    title: string
+    scheduled_start_time: string | null
+    stream_url: string | null
+  }
+  const row = claimed as StreamRow
+
+  const result = await dispatchEvent(row.workspace_id, "stream.created", {
+    title: row.title,
+    scheduledStartTime: row.scheduled_start_time,
+    streamUrl: row.stream_url,
+  })
+
+  response.status(200).json({ ok: true, ...result })
+}

--- a/api/notifications/requests.ts
+++ b/api/notifications/requests.ts
@@ -1,0 +1,126 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+import { dispatchEvent } from "../../server/notifications/dispatch.js"
+import { isNotificationEventKey } from "../../src/data/notification-events.js"
+
+type ApiRequest = {
+  method?: string
+  body?: unknown
+  headers?: Record<string, string | string[] | undefined>
+}
+
+type ApiResponse = {
+  status: (code: number) => ApiResponse
+  json: (body: unknown) => void
+  setHeader: (name: string, value: string) => void
+}
+
+type RequestEventType =
+  | "request.created"
+  | "request.status_changed"
+  | "request.archived"
+
+type Body = {
+  event_type?: string
+  workspace_id?: string
+  title?: string
+  status?: string | null
+  requester_name?: string | null
+  link_url?: string
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined> | undefined,
+  name: string,
+): string | null {
+  if (!headers) return null
+  const raw = headers[name] ?? headers[name.toLowerCase()]
+  if (!raw) return null
+  return Array.isArray(raw) ? raw[0] ?? null : raw
+}
+
+function safeEqual(a: string, b: string): boolean {
+  const ab = Buffer.from(a)
+  const bb = Buffer.from(b)
+  if (ab.length !== bb.length) return false
+  return timingSafeEqual(ab, bb)
+}
+
+// HMAC contract: sender signs JSON.stringify(body) with the shared secret,
+// sends the hex digest in X-Signature. Both sides must call JSON.stringify
+// on the same object shape — keep payload keys stable and avoid undefineds.
+function verifySignature(body: unknown, provided: string | null): boolean {
+  const secret = process.env.NOTIFICATIONS_INGEST_SECRET
+  if (!secret || !provided) return false
+  const expected = createHmac("sha256", secret)
+    .update(JSON.stringify(body ?? {}))
+    .digest("hex")
+  return safeEqual(expected, provided)
+}
+
+export default async function handler(request: ApiRequest, response: ApiResponse) {
+  response.setHeader("Content-Type", "application/json")
+
+  if (request.method !== "POST") {
+    response.status(405).json({ error: "Method not allowed" })
+    return
+  }
+
+  if (!verifySignature(request.body, headerValue(request.headers, "x-signature"))) {
+    response.status(401).json({ error: "Invalid signature" })
+    return
+  }
+
+  const body = (request.body ?? {}) as Body
+  const { event_type, workspace_id, title, link_url } = body
+
+  if (
+    typeof event_type !== "string" ||
+    typeof workspace_id !== "string" || !workspace_id ||
+    typeof title !== "string" || !title ||
+    typeof link_url !== "string" || !link_url
+  ) {
+    response.status(400).json({ error: "Missing fields" })
+    return
+  }
+
+  if (
+    !isNotificationEventKey(event_type) ||
+    (event_type !== "request.created" &&
+      event_type !== "request.status_changed" &&
+      event_type !== "request.archived")
+  ) {
+    response.status(400).json({ error: "Unsupported event_type" })
+    return
+  }
+
+  const requesterName = typeof body.requester_name === "string" ? body.requester_name : null
+
+  let result: { attempted: number; succeeded: number }
+  if (event_type === "request.status_changed") {
+    if (typeof body.status !== "string" || !body.status) {
+      response.status(400).json({ error: "status required for request.status_changed" })
+      return
+    }
+    result = await dispatchEvent(workspace_id, event_type as RequestEventType, {
+      title,
+      status: body.status,
+      requesterName,
+      linkUrl: link_url,
+    })
+  } else if (event_type === "request.archived") {
+    result = await dispatchEvent(workspace_id, event_type as RequestEventType, {
+      title,
+      requesterName,
+      linkUrl: link_url,
+    })
+  } else {
+    result = await dispatchEvent(workspace_id, "request.created", {
+      title,
+      status: typeof body.status === "string" ? body.status : null,
+      requesterName,
+      linkUrl: link_url,
+    })
+  }
+
+  response.status(200).json({ ok: true, ...result })
+}

--- a/docs/phases/phase-28-notification-routing.sql
+++ b/docs/phases/phase-28-notification-routing.sql
@@ -1,0 +1,90 @@
+-- ============================================================
+-- Phase 28 — Notification Routing (Telegram groups & topics)
+-- Requires: Phase 02 (workspaces), Phase 08 (private helpers),
+--           Phase 13 (streams, zoom_meetings), Phase 21+23 (telegram_groups)
+-- ============================================================
+-- Lets workspace admins map app event types (e.g. stream.created,
+-- request.status_changed) to one or more Telegram destinations
+-- (a group, optionally a forum topic within that group).
+--
+-- The dispatcher (server/notifications/dispatch.ts) reads enabled
+-- rows for a given (workspace_id, event_type) and fans out a
+-- formatted message to each destination. Failures are logged into
+-- bug_reports.
+--
+-- Stream / Zoom dedupe: notified_at is stamped the first time a
+-- row is sent. Subsequent updates or sync passes never re-fire.
+-- ============================================================
+
+-- ------------------------------------------------------------
+-- Step 1: notified_at on streams + zoom_meetings (dedupe)
+-- ------------------------------------------------------------
+
+ALTER TABLE public.streams
+  ADD COLUMN IF NOT EXISTS notified_at timestamptz NULL;
+
+ALTER TABLE public.zoom_meetings
+  ADD COLUMN IF NOT EXISTS notified_at timestamptz NULL;
+
+-- ------------------------------------------------------------
+-- Step 2: notification_routes
+-- ------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.notification_routes (
+  id            uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id  uuid        NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  event_type    text        NOT NULL,
+  group_chat_id text        NOT NULL REFERENCES public.telegram_groups(chat_id) ON DELETE CASCADE,
+  thread_id     bigint      NULL,
+  enabled       boolean     NOT NULL DEFAULT true,
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  updated_at    timestamptz NOT NULL DEFAULT now()
+);
+
+-- Two partial unique indexes so the same destination can't be configured
+-- twice for the same event. Split because NULLs are never equal in a plain
+-- UNIQUE constraint (which would allow duplicate "no topic" rows).
+CREATE UNIQUE INDEX IF NOT EXISTS notification_routes_unique_with_topic
+  ON public.notification_routes (workspace_id, event_type, group_chat_id, thread_id)
+  WHERE thread_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS notification_routes_unique_no_topic
+  ON public.notification_routes (workspace_id, event_type, group_chat_id)
+  WHERE thread_id IS NULL;
+
+CREATE INDEX IF NOT EXISTS notification_routes_lookup_idx
+  ON public.notification_routes (workspace_id, event_type) WHERE enabled = true;
+
+CREATE TRIGGER set_notification_routes_updated_at
+  BEFORE UPDATE ON public.notification_routes
+  FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- ------------------------------------------------------------
+-- Step 3: RLS — workspace members can read; admins manage
+-- ------------------------------------------------------------
+
+ALTER TABLE public.notification_routes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "notification_routes_select" ON public.notification_routes;
+CREATE POLICY "notification_routes_select" ON public.notification_routes
+  FOR SELECT TO authenticated
+  USING (
+    private.is_workspace_member(workspace_id)
+    OR private.current_user_can('can_manage_roles')
+  );
+
+DROP POLICY IF EXISTS "notification_routes_insert" ON public.notification_routes;
+CREATE POLICY "notification_routes_insert" ON public.notification_routes
+  FOR INSERT TO authenticated
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "notification_routes_update" ON public.notification_routes;
+CREATE POLICY "notification_routes_update" ON public.notification_routes
+  FOR UPDATE TO authenticated
+  USING (private.current_user_can('can_manage_roles'))
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "notification_routes_delete" ON public.notification_routes;
+CREATE POLICY "notification_routes_delete" ON public.notification_routes
+  FOR DELETE TO authenticated
+  USING (private.current_user_can('can_manage_roles'));

--- a/server/notifications/dispatch.ts
+++ b/server/notifications/dispatch.ts
@@ -1,0 +1,253 @@
+import { getSupabaseAdmin } from "../supabase-admin.js"
+import { sendTelegramMessageDetailed } from "../telegram.js"
+import {
+  isNotificationEventKey,
+  type NotificationEventKey,
+} from "../../src/data/notification-events.js"
+
+export type StreamCreatedPayload = {
+  title: string
+  scheduledStartTime: string | null
+  streamUrl: string | null
+}
+
+export type MeetingCreatedPayload = {
+  topic: string
+  startTime: string | null
+  joinUrl: string | null
+}
+
+export type RequestCreatedPayload = {
+  title: string
+  status: string | null
+  requesterName: string | null
+  linkUrl: string
+}
+
+export type RequestStatusChangedPayload = {
+  title: string
+  status: string
+  requesterName?: string | null
+  linkUrl: string
+}
+
+export type RequestArchivedPayload = {
+  title: string
+  requesterName?: string | null
+  linkUrl: string
+}
+
+export type BookingCreatedPayload = {
+  title: string
+  status?: string | null
+  requesterName?: string | null
+  linkUrl: string
+}
+
+export type BookingStatusChangedPayload = {
+  title: string
+  status: string
+  linkUrl: string
+}
+
+export type EventPayloadMap = {
+  "stream.created": StreamCreatedPayload
+  "meeting.created": MeetingCreatedPayload
+  "request.created": RequestCreatedPayload
+  "request.status_changed": RequestStatusChangedPayload
+  "request.archived": RequestArchivedPayload
+  "booking.created": BookingCreatedPayload
+  "booking.status_changed": BookingStatusChangedPayload
+}
+
+type RouteRow = {
+  id: string
+  group_chat_id: string
+  thread_id: number | null
+  telegram_groups: { active: boolean; removed_at: string | null } | null
+}
+
+// Telegram HTML parser only special-cases &, <, >.
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+}
+
+function formatScheduled(scheduled: string | null): string | null {
+  if (!scheduled) return null
+  const date = new Date(scheduled)
+  if (Number.isNaN(date.getTime())) return null
+  return date.toUTCString()
+}
+
+function buildMessage<K extends NotificationEventKey>(
+  eventType: K,
+  payload: EventPayloadMap[K],
+): string {
+  switch (eventType) {
+    case "stream.created": {
+      const p = payload as StreamCreatedPayload
+      const lines: string[] = [`<b>New YouTube stream</b>`, "", escapeHtml(p.title)]
+      const when = formatScheduled(p.scheduledStartTime)
+      if (when) lines.push(`Scheduled for ${escapeHtml(when)}`)
+      if (p.streamUrl) lines.push("", `<a href="${p.streamUrl}">Open stream</a>`)
+      return lines.join("\n")
+    }
+    case "meeting.created": {
+      const p = payload as MeetingCreatedPayload
+      const lines: string[] = [`<b>New Zoom meeting</b>`, "", escapeHtml(p.topic)]
+      const when = formatScheduled(p.startTime)
+      if (when) lines.push(`Scheduled for ${escapeHtml(when)}`)
+      if (p.joinUrl) lines.push("", `<a href="${p.joinUrl}">Join meeting</a>`)
+      return lines.join("\n")
+    }
+    case "request.created": {
+      const p = payload as RequestCreatedPayload
+      const lines: string[] = [`<b>New request</b>`, "", escapeHtml(p.title)]
+      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
+      if (p.status) lines.push(`Status: <i>${escapeHtml(p.status)}</i>`)
+      lines.push("", `<a href="${p.linkUrl}">Open request</a>`)
+      return lines.join("\n")
+    }
+    case "request.status_changed": {
+      const p = payload as RequestStatusChangedPayload
+      const lines: string[] = [
+        `<b>Request status updated</b>`,
+        "",
+        escapeHtml(p.title),
+        `Status: <i>${escapeHtml(p.status)}</i>`,
+      ]
+      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
+      lines.push("", `<a href="${p.linkUrl}">Open request</a>`)
+      return lines.join("\n")
+    }
+    case "request.archived": {
+      const p = payload as RequestArchivedPayload
+      const lines: string[] = [`<b>Request archived</b>`, "", escapeHtml(p.title)]
+      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
+      lines.push("", `<a href="${p.linkUrl}">Open request</a>`)
+      return lines.join("\n")
+    }
+    case "booking.created": {
+      const p = payload as BookingCreatedPayload
+      const lines: string[] = [`<b>New equipment booking</b>`, "", escapeHtml(p.title)]
+      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
+      if (p.status) lines.push(`Status: <i>${escapeHtml(p.status)}</i>`)
+      lines.push("", `<a href="${p.linkUrl}">Open booking</a>`)
+      return lines.join("\n")
+    }
+    case "booking.status_changed": {
+      const p = payload as BookingStatusChangedPayload
+      return [
+        `<b>Equipment booking updated</b>`,
+        "",
+        escapeHtml(p.title),
+        `Status: <i>${escapeHtml(p.status)}</i>`,
+        "",
+        `<a href="${p.linkUrl}">Open booking</a>`,
+      ].join("\n")
+    }
+  }
+}
+
+async function logDeliveryFailure(args: {
+  workspaceId: string
+  eventType: NotificationEventKey
+  routeId: string
+  groupChatId: string
+  threadId: number | null
+  errorCode: number | null
+  description: string
+  payload: unknown
+}): Promise<void> {
+  try {
+    const admin = getSupabaseAdmin()
+    const summary = `Telegram notification failed (${args.eventType} → ${args.groupChatId}${args.threadId !== null ? `/${args.threadId}` : ""}): ${args.description.slice(0, 200)}`
+    await admin.from("bug_reports").insert({
+      description: summary.slice(0, 2000),
+      error_context: {
+        source: "notifications.dispatch",
+        workspace_id: args.workspaceId,
+        event_type: args.eventType,
+        route_id: args.routeId,
+        group_chat_id: args.groupChatId,
+        thread_id: args.threadId,
+        telegram_error_code: args.errorCode,
+        telegram_description: args.description,
+        payload: args.payload,
+      },
+    })
+  } catch (logErr) {
+    // Last-resort console: never let logging crash the dispatcher.
+    console.error("Failed to log notification delivery failure:", logErr)
+  }
+}
+
+export async function dispatchEvent<K extends NotificationEventKey>(
+  workspaceId: string,
+  eventType: K,
+  payload: EventPayloadMap[K],
+): Promise<{ attempted: number; succeeded: number }> {
+  if (!isNotificationEventKey(eventType)) {
+    return { attempted: 0, succeeded: 0 }
+  }
+
+  const admin = getSupabaseAdmin()
+  const { data, error } = await admin
+    .from("notification_routes")
+    .select("id, group_chat_id, thread_id, telegram_groups(active, removed_at)")
+    .eq("workspace_id", workspaceId)
+    .eq("event_type", eventType)
+    .eq("enabled", true)
+
+  if (error) {
+    await logDeliveryFailure({
+      workspaceId,
+      eventType,
+      routeId: "",
+      groupChatId: "",
+      threadId: null,
+      errorCode: null,
+      description: `Route lookup failed: ${error.message}`,
+      payload,
+    })
+    return { attempted: 0, succeeded: 0 }
+  }
+
+  const routes = ((data ?? []) as unknown as RouteRow[]).filter((r) => {
+    const group = Array.isArray(r.telegram_groups) ? r.telegram_groups[0] : r.telegram_groups
+    return group?.active === true && !group.removed_at
+  })
+
+  if (routes.length === 0) return { attempted: 0, succeeded: 0 }
+
+  const text = buildMessage(eventType, payload)
+  let succeeded = 0
+
+  for (const route of routes) {
+    const send = await sendTelegramMessageDetailed(route.group_chat_id, text, {
+      parseMode: "HTML",
+      disableLinkPreview: true,
+      ...(route.thread_id !== null ? { threadId: route.thread_id } : {}),
+    })
+
+    if (send.ok) {
+      succeeded += 1
+    } else {
+      await logDeliveryFailure({
+        workspaceId,
+        eventType,
+        routeId: route.id,
+        groupChatId: route.group_chat_id,
+        threadId: route.thread_id,
+        errorCode: send.errorCode,
+        description: send.description,
+        payload,
+      })
+    }
+  }
+
+  return { attempted: routes.length, succeeded }
+}

--- a/server/telegram.ts
+++ b/server/telegram.ts
@@ -10,6 +10,8 @@ export type TelegramSendResult = {
 export type SendMessageOptions = {
   threadId?: number
   replyToMessageId?: number
+  parseMode?: "HTML" | "MarkdownV2" | "Markdown"
+  disableLinkPreview?: boolean
 }
 
 export async function sendTelegramMessage(
@@ -22,6 +24,10 @@ export async function sendTelegramMessage(
   try {
     const body: Record<string, unknown> = { chat_id: chatId, text }
     if (typeof options.threadId === "number") body.message_thread_id = options.threadId
+    if (options.parseMode) body.parse_mode = options.parseMode
+    if (options.disableLinkPreview) {
+      body.link_preview_options = { is_disabled: true }
+    }
     if (typeof options.replyToMessageId === "number") {
       body.reply_parameters = {
         message_id: options.replyToMessageId,

--- a/server/telegram.ts
+++ b/server/telegram.ts
@@ -14,13 +14,20 @@ export type SendMessageOptions = {
   disableLinkPreview?: boolean
 }
 
-export async function sendTelegramMessage(
+export type TelegramSendDetailed =
+  | { ok: true; result: TelegramSendResult | null }
+  | { ok: false; errorCode: number | null; description: string }
+
+// Variant that surfaces the API error so callers (e.g. the routing
+// dispatcher) can log meaningful failure context. The simpler
+// `sendTelegramMessage` keeps the existing fire-and-forget contract.
+export async function sendTelegramMessageDetailed(
   chatId: number | string,
   text: string,
   options: SendMessageOptions = {},
-): Promise<TelegramSendResult | null> {
+): Promise<TelegramSendDetailed> {
   const token = process.env.TELEGRAM_BOT_TOKEN
-  if (!token) return null
+  if (!token) return { ok: false, errorCode: null, description: "TELEGRAM_BOT_TOKEN not configured" }
   try {
     const body: Record<string, unknown> = { chat_id: chatId, text }
     if (typeof options.threadId === "number") body.message_thread_id = options.threadId
@@ -39,11 +46,34 @@ export async function sendTelegramMessage(
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
     })
-    const json = (await res.json()) as { ok?: boolean; result?: TelegramSendResult }
-    return json.ok ? json.result ?? null : null
-  } catch {
-    return null
+    const json = (await res.json()) as {
+      ok?: boolean
+      result?: TelegramSendResult
+      error_code?: number
+      description?: string
+    }
+    if (json.ok) return { ok: true, result: json.result ?? null }
+    return {
+      ok: false,
+      errorCode: typeof json.error_code === "number" ? json.error_code : null,
+      description: json.description ?? `HTTP ${res.status}`,
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      errorCode: null,
+      description: error instanceof Error ? error.message : String(error),
+    }
   }
+}
+
+export async function sendTelegramMessage(
+  chatId: number | string,
+  text: string,
+  options: SendMessageOptions = {},
+): Promise<TelegramSendResult | null> {
+  const result = await sendTelegramMessageDetailed(chatId, text, options)
+  return result.ok ? result.result : null
 }
 
 export async function editTelegramMessageText(

--- a/src/data/mutate-streams.ts
+++ b/src/data/mutate-streams.ts
@@ -11,6 +11,7 @@ import {
 } from "@/lib/youtube-client"
 import { fetchStreamById } from "./fetch-streams"
 import { randomId } from "@/utils/random-id"
+import { notifyStreamCreated } from "./notify-event"
 
 export type ThumbnailSource =
   | { type: "file"; file: File }
@@ -297,6 +298,8 @@ export async function createStream(params: CreateStreamParams): Promise<Stream> 
     throw new Error("Created stream could not be reloaded")
   }
 
+  notifyStreamCreated(saved.id)
+
   return saved
 }
 
@@ -539,6 +542,12 @@ export async function syncStreamsFromYouTube(): Promise<Stream[]> {
 
   if (error) {
     throw new Error(error.message)
+  }
+
+  // Fire-and-forget notify for any rows that have never been notified.
+  // The server atomically claims notified_at, so concurrent syncs are safe.
+  for (const row of rows ?? []) {
+    if (!row.notified_at) notifyStreamCreated(row.id)
   }
 
   return (rows ?? []).map((row) => ({

--- a/src/data/mutate-zoom.ts
+++ b/src/data/mutate-zoom.ts
@@ -5,6 +5,7 @@ import { zoomApiFetch, revokeZoomToken } from "@/lib/zoom-client"
 import { fetchZoomMeetingById } from "./fetch-zoom"
 import { formatUtcIsoForZoomApi, parseDateTimeInputToUtcIso } from "@/utils/zoned-date-time"
 import { randomId } from "@/utils/random-id"
+import { notifyMeetingCreated } from "./notify-event"
 
 export type CreateMeetingParams = {
   topic: string
@@ -186,6 +187,8 @@ export async function createZoomMeeting(params: CreateMeetingParams): Promise<Zo
     throw new Error("Created meeting could not be reloaded")
   }
 
+  notifyMeetingCreated(saved.id)
+
   return saved
 }
 
@@ -354,6 +357,12 @@ export async function syncZoomMeetings(): Promise<ZoomMeeting[]> {
 
   if (error) {
     throw new Error(error.message)
+  }
+
+  // Fire-and-forget notify for any rows that have never been notified.
+  // The server atomically claims notified_at, so concurrent syncs are safe.
+  for (const row of rows ?? []) {
+    if (!row.notified_at) notifyMeetingCreated(row.id)
   }
 
   return (rows ?? []).map((row) => ({

--- a/src/data/notification-events.ts
+++ b/src/data/notification-events.ts
@@ -1,0 +1,63 @@
+// Event-type registry for the notification routing system.
+// Imported by the admin UI (to render the list) and by the server
+// dispatcher (to validate incoming event_type values). Keep
+// shared-safe: no browser or Node-only imports.
+
+export type NotificationEventKey =
+  | "stream.created"
+  | "meeting.created"
+  | "request.created"
+  | "request.status_changed"
+  | "request.archived"
+  | "booking.created"
+  | "booking.status_changed";
+
+export type NotificationEventDefinition = {
+  key: NotificationEventKey;
+  label: string;
+  description: string;
+};
+
+export const NOTIFICATION_EVENTS: readonly NotificationEventDefinition[] = [
+  {
+    key: "stream.created",
+    label: "YouTube stream created",
+    description: "Fires when a stream is created in MOC Console or first discovered by syncing with YouTube.",
+  },
+  {
+    key: "meeting.created",
+    label: "Zoom meeting created",
+    description: "Fires when a meeting is created in MOC Console or first discovered by syncing with Zoom.",
+  },
+  {
+    key: "request.created",
+    label: "Request created",
+    description: "Fires when a new request is submitted in the requests app.",
+  },
+  {
+    key: "request.status_changed",
+    label: "Request status changed",
+    description: "Fires whenever a request moves between statuses (e.g. in progress → completed).",
+  },
+  {
+    key: "request.archived",
+    label: "Request archived",
+    description: "Fires when a request is archived.",
+  },
+  {
+    key: "booking.created",
+    label: "Equipment booking created",
+    description: "Fires when a new equipment booking is made in the requests/bookings app.",
+  },
+  {
+    key: "booking.status_changed",
+    label: "Equipment booking status changed",
+    description: "Fires whenever an equipment booking changes status.",
+  },
+] as const;
+
+const KEYS = new Set<string>(NOTIFICATION_EVENTS.map((e) => e.key));
+
+export function isNotificationEventKey(value: string): value is NotificationEventKey {
+  return KEYS.has(value);
+}

--- a/src/data/notification-routes.ts
+++ b/src/data/notification-routes.ts
@@ -1,0 +1,81 @@
+import { supabase } from "@/lib/supabase";
+import type { NotificationEventKey } from "./notification-events";
+
+export type NotificationRoute = {
+  id: string;
+  workspaceId: string;
+  eventType: NotificationEventKey;
+  groupChatId: string;
+  threadId: number | null;
+  enabled: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type Row = {
+  id: string;
+  workspace_id: string;
+  event_type: string;
+  group_chat_id: string;
+  thread_id: number | null;
+  enabled: boolean;
+  created_at: string;
+  updated_at: string;
+};
+
+function rowToRoute(row: Row): NotificationRoute {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    eventType: row.event_type as NotificationEventKey,
+    groupChatId: row.group_chat_id,
+    threadId: row.thread_id,
+    enabled: row.enabled,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+export async function fetchNotificationRoutes(workspaceId: string): Promise<NotificationRoute[]> {
+  const { data, error } = await supabase
+    .from("notification_routes")
+    .select("id, workspace_id, event_type, group_chat_id, thread_id, enabled, created_at, updated_at")
+    .eq("workspace_id", workspaceId)
+    .order("event_type", { ascending: true })
+    .order("created_at", { ascending: true });
+
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map(rowToRoute);
+}
+
+export async function createNotificationRoute(params: {
+  workspaceId: string;
+  eventType: NotificationEventKey;
+  groupChatId: string;
+  threadId: number | null;
+}): Promise<NotificationRoute> {
+  const { data, error } = await supabase
+    .from("notification_routes")
+    .insert({
+      workspace_id: params.workspaceId,
+      event_type: params.eventType,
+      group_chat_id: params.groupChatId,
+      thread_id: params.threadId,
+      enabled: true,
+    })
+    .select("id, workspace_id, event_type, group_chat_id, thread_id, enabled, created_at, updated_at")
+    .single();
+
+  if (error) throw new Error(error.message);
+  return rowToRoute(data as Row);
+}
+
+export async function deleteNotificationRoute(id: string): Promise<void> {
+  const { error } = await supabase.from("notification_routes").delete().eq("id", id);
+  if (error) throw new Error(error.message);
+}
+
+export async function setNotificationRouteEnabled(id: string, enabled: boolean): Promise<void> {
+  const { error } = await supabase.from("notification_routes").update({ enabled }).eq("id", id);
+  if (error) throw new Error(error.message);
+}

--- a/src/data/notify-event.ts
+++ b/src/data/notify-event.ts
@@ -1,0 +1,30 @@
+import { buildSessionHeaders } from "@/lib/api-auth";
+
+// Fire-and-forget POST to the internal notify endpoint. The server
+// atomically claims the row via `notified_at`, so duplicate calls are
+// safe — only the first one fans out to configured Telegram routes.
+function fireNotify(path: string, body: Record<string, unknown>): void {
+  void (async () => {
+    try {
+      const headers = await buildSessionHeaders();
+      await fetch(path, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...headers,
+        },
+        body: JSON.stringify(body),
+      });
+    } catch {
+      // swallow
+    }
+  })();
+}
+
+export function notifyStreamCreated(streamId: string): void {
+  fireNotify("/api/notifications/internal/stream-created", { streamId });
+}
+
+export function notifyMeetingCreated(meetingId: string): void {
+  fireNotify("/api/notifications/internal/meeting-created", { meetingId });
+}

--- a/src/screens/account/settings/connect-events-modal.tsx
+++ b/src/screens/account/settings/connect-events-modal.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Modal } from "@/components/overlays/modal";
+import { Button } from "@/components/controls/button";
+import { Toggle } from "@/components/form/toggle";
+import { Paragraph, Label } from "@/components/display/text";
+import { LoadingSpinner } from "@/components/feedback/spinner";
+import { supabase } from "@/lib/supabase";
+import { useFeedback } from "@/components/feedback/feedback-provider";
+import {
+    NOTIFICATION_EVENTS,
+    type NotificationEventKey,
+} from "@/data/notification-events";
+import {
+    createNotificationRoute,
+    deleteNotificationRoute,
+    type NotificationRoute,
+} from "@/data/notification-routes";
+
+export type ConnectEventsTarget = {
+    workspaceId: string;
+    groupChatId: string;
+    groupTitle: string;
+    threadId: number | null;
+    topicName: string | null;
+};
+
+type ConnectEventsModalProps = {
+    target: ConnectEventsTarget | null;
+    onClose: () => void;
+};
+
+type Row = {
+    id: string;
+    workspace_id: string;
+    event_type: string;
+    group_chat_id: string;
+    thread_id: number | null;
+    enabled: boolean;
+    created_at: string;
+    updated_at: string;
+};
+
+function rowToRoute(row: Row): NotificationRoute {
+    return {
+        id: row.id,
+        workspaceId: row.workspace_id,
+        eventType: row.event_type as NotificationEventKey,
+        groupChatId: row.group_chat_id,
+        threadId: row.thread_id,
+        enabled: row.enabled,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+    };
+}
+
+// Scoped fetch — only the routes for one destination. Splits "thread is null"
+// vs "thread = N" so a NULL filter doesn't accidentally match a numbered topic.
+async function fetchRoutesForTarget(target: ConnectEventsTarget): Promise<NotificationRoute[]> {
+    let query = supabase
+        .from("notification_routes")
+        .select("id, workspace_id, event_type, group_chat_id, thread_id, enabled, created_at, updated_at")
+        .eq("workspace_id", target.workspaceId)
+        .eq("group_chat_id", target.groupChatId);
+    query = target.threadId === null ? query.is("thread_id", null) : query.eq("thread_id", target.threadId);
+    const { data, error } = await query;
+    if (error) throw new Error(error.message);
+    return ((data ?? []) as Row[]).map(rowToRoute);
+}
+
+export function ConnectEventsModal({ target, onClose }: ConnectEventsModalProps) {
+    const { toast } = useFeedback();
+    const [routes, setRoutes] = useState<NotificationRoute[]>([]);
+    const [isLoading, setIsLoading] = useState(false);
+    const [pendingKey, setPendingKey] = useState<NotificationEventKey | null>(null);
+
+    useEffect(() => {
+        if (!target) {
+            setRoutes([]);
+            return;
+        }
+        let cancelled = false;
+        setIsLoading(true);
+        void (async () => {
+            try {
+                const data = await fetchRoutesForTarget(target);
+                if (!cancelled) setRoutes(data);
+            } catch (error) {
+                if (!cancelled) {
+                    toast({
+                        title: "Couldn't load event connections",
+                        description: error instanceof Error ? error.message : "Unknown error",
+                        variant: "error",
+                    });
+                }
+            } finally {
+                if (!cancelled) setIsLoading(false);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [target, toast]);
+
+    const routeByEvent = useMemo(() => {
+        const m = new Map<NotificationEventKey, NotificationRoute>();
+        for (const r of routes) m.set(r.eventType, r);
+        return m;
+    }, [routes]);
+
+    const handleToggle = useCallback(
+        (eventKey: NotificationEventKey) => async (next: boolean) => {
+            if (!target) return;
+            setPendingKey(eventKey);
+            const existing = routeByEvent.get(eventKey);
+            try {
+                if (next) {
+                    if (existing) return;
+                    const created = await createNotificationRoute({
+                        workspaceId: target.workspaceId,
+                        eventType: eventKey,
+                        groupChatId: target.groupChatId,
+                        threadId: target.threadId,
+                    });
+                    setRoutes((prev) => [...prev, created]);
+                } else {
+                    if (!existing) return;
+                    await deleteNotificationRoute(existing.id);
+                    setRoutes((prev) => prev.filter((r) => r.id !== existing.id));
+                }
+            } catch (error) {
+                toast({
+                    title: next ? "Couldn't connect event" : "Couldn't disconnect event",
+                    description: error instanceof Error ? error.message : "Unknown error",
+                    variant: "error",
+                });
+            } finally {
+                setPendingKey(null);
+            }
+        },
+        [target, routeByEvent, toast],
+    );
+
+    const destinationLabel = target
+        ? target.topicName
+            ? `${target.groupTitle} › ${target.topicName}`
+            : target.threadId !== null
+                ? `${target.groupTitle} › Topic #${target.threadId}`
+                : `${target.groupTitle} › General`
+        : "";
+
+    return (
+        <Modal open={target !== null} onOpenChange={(next) => { if (!next) onClose(); }}>
+            <Modal.Portal>
+                <Modal.Backdrop />
+                <Modal.Positioner>
+                    <Modal.Panel className="w-full max-w-lg">
+                        <Modal.Header>
+                            <div className="flex flex-col gap-1">
+                                <Label.md>Connect events</Label.md>
+                                <Paragraph.xs className="text-quaternary">{destinationLabel}</Paragraph.xs>
+                            </div>
+                        </Modal.Header>
+                        <Modal.Content>
+                            <div className="flex flex-col p-2">
+                                {isLoading ? (
+                                    <div className="flex justify-center py-6">
+                                        <LoadingSpinner size="lg" />
+                                    </div>
+                                ) : (
+                                    NOTIFICATION_EVENTS.map((event) => {
+                                        const connected = routeByEvent.has(event.key);
+                                        return (
+                                            <div
+                                                key={event.key}
+                                                className="flex items-center justify-between gap-3 px-3 py-3 border-b border-tertiary last:border-b-0"
+                                            >
+                                                <div className="flex flex-1 flex-col gap-0.5">
+                                                    <Label.sm>{event.label}</Label.sm>
+                                                    <Paragraph.xs className="text-quaternary">
+                                                        {event.description}
+                                                    </Paragraph.xs>
+                                                </div>
+                                                <Toggle
+                                                    checked={connected}
+                                                    disabled={pendingKey === event.key}
+                                                    onChange={handleToggle(event.key)}
+                                                />
+                                            </div>
+                                        );
+                                    })
+                                )}
+                            </div>
+                        </Modal.Content>
+                        <Modal.Footer>
+                            <Modal.Close>
+                                <Button variant="secondary">Done</Button>
+                            </Modal.Close>
+                        </Modal.Footer>
+                    </Modal.Panel>
+                </Modal.Positioner>
+            </Modal.Portal>
+        </Modal>
+    );
+}

--- a/src/screens/account/settings/telegram-tab.tsx
+++ b/src/screens/account/settings/telegram-tab.tsx
@@ -11,11 +11,13 @@ import {
     setTelegramGroupActive,
     type TelegramGroup,
 } from "@/data/fetch-telegram-groups";
-import { MessagesSquare } from "lucide-react";
+import { Link2, MessagesSquare } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Divider } from "@/components/display/divider";
 import { Decision } from "@/components/display/decision";
 import { Toggle } from "@/components/form/toggle";
+import { Button } from "@/components/controls/button";
+import { ConnectEventsModal, type ConnectEventsTarget } from "./connect-events-modal";
 
 export function TelegramTab() {
     const { toast } = useFeedback();
@@ -24,6 +26,7 @@ export function TelegramTab() {
     const [groups, setGroups] = useState<TelegramGroup[]>([]);
     const [isLoading, setIsLoading] = useState(true);
     const [pendingChatId, setPendingChatId] = useState<string | null>(null);
+    const [connectTarget, setConnectTarget] = useState<ConnectEventsTarget | null>(null);
 
     const loadGroups = useCallback(async () => {
         if (!currentWorkspaceId) {
@@ -72,66 +75,99 @@ export function TelegramTab() {
         [toast],
     );
 
+    const openConnect = (group: TelegramGroup, threadId: number | null, topicName: string | null) => {
+        if (!currentWorkspaceId) return;
+        setConnectTarget({
+            workspaceId: currentWorkspaceId,
+            groupChatId: group.chatId,
+            groupTitle: group.title || `(chat ${group.chatId})`,
+            threadId,
+            topicName,
+        });
+    };
+
     return (
-        <Section>
-            <Section.Header title="Telegram groups" />
+        <>
+            <Section>
+                <Section.Header
+                    title="Telegram groups"
+                    description="Toggle a group active to allow notifications, then click the link icon on a group or topic to connect events."
+                />
 
-            <Divider className="py-6" />
+                <Divider className="py-6" />
 
-            <Section.Body className="gap-4">
-                <Decision value={groups} loading={isLoading}>
-                    <Decision.Loading>
-                        <LoadingSpinner size="lg" />
-                    </Decision.Loading>
-                    <Decision.Empty>
-                        <EmptyState
-                            icon={<MessagesSquare />}
-                            title="No groups yet"
-                            description={
-                                currentWorkspaceSlug
-                                    ? `Add the bot to a Telegram group, then send "/register_group ${currentWorkspaceSlug}" in that group to register it to this workspace.`
-                                    : "Add the bot to a Telegram group, then send /register_group <workspace-slug> in that group."
-                            }
-                        />
-                    </Decision.Empty>
-                    <Decision.Data>
-                        {groups.map((group) => (
-                            <Card key={group.chatId}>
-                                <Card.Header tight>
-                                    <div className="flex flex-1 flex-col gap-1">
-                                        <Label.md>{group.title || "(untitled)"}</Label.md>
-                                        <Paragraph.xs className="text-quaternary">
-                                            chat id {group.chatId}
-                                        </Paragraph.xs>
-                                    </div>
-                                    <Toggle
-                                        checked={group.active}
-                                        disabled={pendingChatId === group.chatId}
-                                        onChange={handleToggleActive(group.chatId)}
-                                    />
-
-                                </Card.Header>
-                                {group.topics.length > 0 && (
-                                    <Card.Content className="flex flex-col">
-                                        {group.topics.map((topic) => (
-                                            <div
-                                                key={topic.threadId}
-                                                className="flex items-center justify-between px-3 py-2 border-b border-tertiary last:border-b-0"
-                                            >
-                                                <div className="flex items-center gap-2">
-                                                    <Label.sm>{topic.name || "(unnamed)"}</Label.sm>
-                                                    <Paragraph.xs className="text-quaternary">#{topic.threadId}</Paragraph.xs>
+                <Section.Body className="gap-4">
+                    <Decision value={groups} loading={isLoading}>
+                        <Decision.Loading>
+                            <LoadingSpinner size="lg" />
+                        </Decision.Loading>
+                        <Decision.Empty>
+                            <EmptyState
+                                icon={<MessagesSquare />}
+                                title="No groups yet"
+                                description={
+                                    currentWorkspaceSlug
+                                        ? `Add the bot to a Telegram group, then send "/register_group ${currentWorkspaceSlug}" in that group to register it to this workspace.`
+                                        : "Add the bot to a Telegram group, then send /register_group <workspace-slug> in that group."
+                                }
+                            />
+                        </Decision.Empty>
+                        <Decision.Data>
+                            {groups.map((group) => (
+                                <Card key={group.chatId}>
+                                    <Card.Header tight>
+                                        <div className="flex flex-1 flex-col gap-1">
+                                            <Label.md>{group.title || "(untitled)"}</Label.md>
+                                            <Paragraph.xs className="text-quaternary">
+                                                chat id {group.chatId}
+                                            </Paragraph.xs>
+                                        </div>
+                                        <div className="flex items-center gap-3">
+                                            <Button.Icon
+                                                variant="ghost"
+                                                icon={<Link2 />}
+                                                disabled={!group.active}
+                                                onClick={() => openConnect(group, null, null)}
+                                                aria-label={`Connect events to ${group.title || "this group"}`}
+                                            />
+                                            <Toggle
+                                                checked={group.active}
+                                                disabled={pendingChatId === group.chatId}
+                                                onChange={handleToggleActive(group.chatId)}
+                                            />
+                                        </div>
+                                    </Card.Header>
+                                    {group.topics.length > 0 && (
+                                        <Card.Content className="flex flex-col">
+                                            {group.topics.map((topic) => (
+                                                <div
+                                                    key={topic.threadId}
+                                                    className="flex items-center justify-between px-3 py-2 border-b border-tertiary last:border-b-0"
+                                                >
+                                                    <div className="flex items-center gap-2">
+                                                        <Label.sm>{topic.name || "(unnamed)"}</Label.sm>
+                                                        <Paragraph.xs className="text-quaternary">#{topic.threadId}</Paragraph.xs>
+                                                        {topic.closed && <Badge label="closed" color="gray" variant="outline" />}
+                                                    </div>
+                                                    <Button.Icon
+                                                        variant="ghost"
+                                                        icon={<Link2 />}
+                                                        disabled={!group.active || topic.closed}
+                                                        onClick={() => openConnect(group, topic.threadId, topic.name || null)}
+                                                        aria-label={`Connect events to ${topic.name || `topic ${topic.threadId}`}`}
+                                                    />
                                                 </div>
-                                                {topic.closed && <Badge label="closed" color="gray" variant="outline" />}
-                                            </div>
-                                        ))}
-                                    </Card.Content>
-                                )}
-                            </Card>
-                        ))}
-                    </Decision.Data>
-                </Decision>
-            </Section.Body>
-        </Section>
+                                            ))}
+                                        </Card.Content>
+                                    )}
+                                </Card>
+                            ))}
+                        </Decision.Data>
+                    </Decision>
+                </Section.Body>
+            </Section>
+
+            <ConnectEventsModal target={connectTarget} onClose={() => setConnectTarget(null)} />
+        </>
     );
 }


### PR DESCRIPTION
## Summary

- Adds a workspace-scoped routing system mapping app events (stream/meeting created, request lifecycle, booking lifecycle) to one or more Telegram groups or forum topics. Configured per-destination from Account → Settings → Telegram via a connect-icon modal listing events with on/off toggles.
- Adds two HMAC-signed external ingest endpoints (`/api/notifications/requests`, `/api/notifications/bookings`) so the sibling moc-request app can fan out create/status events into the same routing pipeline.
- Stream and Zoom-meeting notifications dedupe via a new `notified_at` column on `streams` and `zoom_meetings`; the server atomically claims the row so manual syncs only fire once.
- Delivery failures (bot kicked, group missing, etc.) are logged into `bug_reports` for visibility. Existing assignee DM notifications are untouched and run alongside.
- Also includes prior commit prettifying Telegram assignment message formatting.

## Test plan

- [ ] Apply migration `docs/phases/phase-28-notification-routing.sql` on staging; verify RLS denies non-admins from editing `notification_routes`.
- [ ] In Account → Settings → Telegram, click the link icon on a registered group; toggle a few events on/off; confirm rows appear/disappear in `notification_routes`.
- [ ] Create a YouTube stream in-app; confirm a message lands in the connected group and `streams.notified_at` is set.
- [ ] Schedule a stream in YouTube Studio directly, then click Refresh in the app. Confirm exactly one message; click Refresh again, confirm no duplicate.
- [ ] Repeat for a Zoom meeting (in-app create + sync).
- [ ] `curl -X POST /api/notifications/requests` with a valid `X-Signature` and a payload for each of `request.created`, `request.status_changed`, `request.archived`; confirm messages appear and 401 returns on a tampered signature.
- [ ] Same for `/api/notifications/bookings`.
- [ ] Configure a route to a group the bot has been kicked from; trigger an event and confirm a row appears in `bug_reports` while other routes in the fan-out still deliver.

🤖 Generated with [Claude Code](https://claude.com/claude-code)