### PR TITLE
fix(auth): verify email OTPs client-side to survive link pre-fetch

### DIFF
--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -51,6 +51,52 @@ function hasPasswordRecoveryParams() {
     return hashParams.get("type") === "recovery" || searchParams.get("type") === "recovery"
 }
 
+const VERIFIABLE_OTP_TYPES = ["signup", "recovery", "invite", "magiclink", "email_change", "email"] as const
+type VerifiableOtpType = typeof VERIFIABLE_OTP_TYPES[number]
+
+function isVerifiableOtpType(value: string): value is VerifiableOtpType {
+    return (VERIFIABLE_OTP_TYPES as readonly string[]).includes(value)
+}
+
+async function verifyEmailOtpFromUrl(): Promise<{ wasRecovery: boolean }> {
+    if (typeof window === "undefined") {
+        return { wasRecovery: false }
+    }
+
+    const searchParams = new URLSearchParams(window.location.search)
+    const tokenHash = searchParams.get("token_hash")
+    const rawType = searchParams.get("type")
+
+    if (!tokenHash || !rawType || !isVerifiableOtpType(rawType)) {
+        return { wasRecovery: false }
+    }
+
+    const wasRecovery = rawType === "recovery"
+
+    const { error } = await supabase.auth.verifyOtp({
+        token_hash: tokenHash,
+        type: rawType,
+    })
+
+    searchParams.delete("token_hash")
+    searchParams.delete("type")
+    const nextSearch = searchParams.toString()
+    const basePath = `${window.location.pathname}${nextSearch ? `?${nextSearch}` : ""}`
+
+    if (error) {
+        const errorHash = new URLSearchParams({
+            error: "access_denied",
+            error_code: "otp_expired",
+            error_description: error.message,
+        }).toString()
+        window.history.replaceState({}, "", `${basePath}#${errorHash}`)
+        return { wasRecovery }
+    }
+
+    window.history.replaceState({}, "", `${basePath}${window.location.hash}`)
+    return { wasRecovery }
+}
+
 function getResetPasswordRedirectUrl() {
     if (typeof window === "undefined") {
         return undefined
@@ -133,6 +179,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
         async function initializeAuth() {
             await exchangeAuthCodeFromUrl()
+            const { wasRecovery } = await verifyEmailOtpFromUrl()
 
             const { data: { session } } = await supabase.auth.getSession()
 
@@ -142,7 +189,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
             setSession(session)
             setUser(session?.user ?? null)
-            setIsPasswordRecovery(hasPasswordRecoveryParams())
+            setIsPasswordRecovery(wasRecovery || hasPasswordRecoveryParams())
             clearCurrentWorkspaceCache()
 
             if (!session?.user) {

--- a/src/screens/auth/password-recovery.tsx
+++ b/src/screens/auth/password-recovery.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useMemo, useState } from "react"
 import type { ChangeEvent, FormEvent } from "react"
 import { Link } from "react-router-dom"
 import { Lock } from "lucide-react"
@@ -10,6 +10,18 @@ import { useAuth } from "@/lib/auth-context"
 import { routes } from "@/screens/console-routes"
 import { AuthLayout } from "./auth-layout"
 
+function getLinkErrorFromUrl(): string | null {
+    if (typeof window === "undefined") return null
+    const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""))
+    const searchParams = new URLSearchParams(window.location.search)
+    const description = hashParams.get("error_description") ?? searchParams.get("error_description")
+    if (description) return description
+    const code = hashParams.get("error_code") ?? searchParams.get("error_code")
+    if (code) return code
+    const error = hashParams.get("error") ?? searchParams.get("error")
+    return error
+}
+
 export function PasswordRecoveryScreen() {
     const { loading: authLoading, isPasswordRecovery, session, updatePassword } = useAuth()
     const [password, setPassword] = useState("")
@@ -17,6 +29,7 @@ export function PasswordRecoveryScreen() {
     const [error, setError] = useState("")
     const [success, setSuccess] = useState(false)
     const [isSubmitting, setIsSubmitting] = useState(false)
+    const linkError = useMemo(() => (authLoading ? null : getLinkErrorFromUrl()), [authLoading])
 
     function handlePasswordChange(event: ChangeEvent<HTMLInputElement>) {
         setPassword(event.target.value)
@@ -64,13 +77,16 @@ export function PasswordRecoveryScreen() {
     }
 
     if (!isPasswordRecovery) {
+        const title = linkError ? "This link is no longer valid" : "Recovery link required"
+        const description = linkError
+            ? linkError
+            : "Open the password recovery link from your email to set a new password."
+
         return (
             <AuthLayout>
                 <div className="space-y-4 text-center">
-                    <h2 className="title-h6">Recovery link required</h2>
-                    <p className="paragraph-sm text-tertiary">
-                        Open the password recovery link from your email to set a new password.
-                    </p>
+                    <h2 className="title-h6">{title}</h2>
+                    <p className="paragraph-sm text-tertiary">{description}</p>
                     <Link to={`/${routes.resetPassword}`}>
                         <Button variant="secondary" className="w-full mt-2">Request a new link</Button>
                     </Link>


### PR DESCRIPTION
## Summary

- Email scanners (Gmail, enterprise mail filters) were pre-fetching the `{{ .ConfirmationURL }}` link in password-reset emails, consuming the one-time token before the user clicked. Supabase then bounced them to `/password-recovery` with `otp_expired`, showing the generic "Recovery link required" screen with no hint of the real cause.
- Switch to the `token_hash` flow: the app reads `token_hash` + `type` from the URL on boot and calls `supabase.auth.verifyOtp` client-side, so the token is only spent in the user's actual browser.
- Surface the underlying `error_description` / `error_code` from the URL on the recovery screen when a link comes back invalid, instead of the generic copy.

## Follow-up (Supabase Dashboard)

The Auth → Email templates need their links updated to point directly at the app so the new flow takes effect:

- Reset Password: `{{ .SiteURL }}/password-recovery?token_hash={{ .TokenHash }}&type=recovery`
- Confirm Sign Up: `{{ .SiteURL }}/login?token_hash={{ .TokenHash }}&type=signup`

The code change handles all `verifyOtp` types (`signup`, `recovery`, `invite`, `magiclink`, `email_change`, `email`), so other templates can use the same pattern on whichever destination route makes sense.

## Test plan

- [ ] Update the Reset Password email template in Supabase to use the new `{{ .TokenHash }}` URL
- [ ] Trigger a password reset, open the email in Gmail, click the link
- [ ] Confirm landing on `/password-recovery` shows the "Choose a new password" form (not "Recovery link required")
- [ ] Submit a new password and confirm it updates and redirects to dashboard/login
- [ ] Confirm a manually expired/already-used link shows the underlying error message instead of the generic copy
- [ ] Repeat for Confirm Sign Up template once updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)