### PR TITLE
refactor(auth): tighten password recovery flow + fix success redirect

### DIFF
--- a/src/screens/auth/auth-layout.tsx
+++ b/src/screens/auth/auth-layout.tsx
@@ -1,17 +1,55 @@
 import type { ReactNode } from "react"
+import { cn } from "@/utils/cn"
 
-export function AuthLayout({ children }: { children: ReactNode }) {
+type AuthLayoutProps = {
+    children: ReactNode
+    step?: number
+    totalSteps?: number
+}
+
+export function AuthLayout({ children, step, totalSteps }: AuthLayoutProps) {
+    const showSteps =
+        typeof step === "number" &&
+        typeof totalSteps === "number" &&
+        totalSteps > 1
+
     return (
-        <div className="flex min-h-dvh items-center justify-center bg-secondary px-4">
-            <div className="w-full max-w-md space-y-6">
+        <div className="flex min-h-dvh items-center justify-center bg-secondary px-4 py-8">
+            <div className="w-full max-w-md space-y-5">
                 <div className="text-center space-y-1">
                     <h1 className="title-h5">MOC Console</h1>
-                    <p className="paragraph-sm text-tertiary">Church media production console</p>
+                    <p className="paragraph-sm text-tertiary">
+                        Church media production console
+                    </p>
                 </div>
+                {showSteps && <FlowSteps current={step} total={totalSteps} />}
                 <div className="rounded-xl border border-secondary bg-primary p-6 shadow-xs">
                     {children}
                 </div>
             </div>
+        </div>
+    )
+}
+
+function FlowSteps({ current, total }: { current: number; total: number }) {
+    return (
+        <div
+            className="flex items-center gap-1.5 px-1"
+            role="progressbar"
+            aria-valuemin={1}
+            aria-valuemax={total}
+            aria-valuenow={current}
+            aria-label={`Step ${current} of ${total}`}
+        >
+            {Array.from({ length: total }).map((_, i) => (
+                <span
+                    key={i}
+                    className={cn(
+                        "h-1 flex-1 rounded-full transition-colors duration-500",
+                        i + 1 <= current ? "bg-brand_solid" : "bg-quaternary",
+                    )}
+                />
+            ))}
         </div>
     )
 }

--- a/src/screens/auth/password-recovery.tsx
+++ b/src/screens/auth/password-recovery.tsx
@@ -1,75 +1,114 @@
 import { useEffect, useMemo, useState } from "react"
-import type { ChangeEvent, FormEvent } from "react"
+import type { FormEvent } from "react"
 import { Link, useNavigate } from "react-router-dom"
-import { Lock } from "lucide-react"
+import {
+    AlertCircle,
+    ArrowRight,
+    CheckCircle2,
+    Eye,
+    EyeOff,
+    Lock,
+} from "lucide-react"
 import { Button } from "@/components/controls/button"
 import { Spinner } from "@/components/feedback/spinner"
 import { Input } from "@/components/form/input"
 import { FormLabel } from "@/components/form/form-label"
 import { useAuth } from "@/lib/auth-context"
 import { routes } from "@/screens/console-routes"
+import { cn } from "@/utils/cn"
 import { AuthLayout } from "./auth-layout"
+
+type Strength = "weak" | "medium" | "strong"
+
+const MIN_PASSWORD_LENGTH = 8
+const REDIRECT_COUNTDOWN_SECONDS = 4
+
+function evaluateStrength(password: string): Strength {
+    if (password.length < MIN_PASSWORD_LENGTH) return "weak"
+    let signals = 0
+    if (/[a-z]/.test(password) && /[A-Z]/.test(password)) signals++
+    if (/\d/.test(password)) signals++
+    if (/[^a-zA-Z0-9]/.test(password)) signals++
+    if (password.length >= 14) signals++
+    if (signals >= 3) return "strong"
+    if (signals >= 1) return "medium"
+    return "weak"
+}
 
 function getLinkErrorFromUrl(): string | null {
     if (typeof window === "undefined") return null
     const hashParams = new URLSearchParams(window.location.hash.replace(/^#/, ""))
     const searchParams = new URLSearchParams(window.location.search)
-    const description = hashParams.get("error_description") ?? searchParams.get("error_description")
+    const description =
+        hashParams.get("error_description") ??
+        searchParams.get("error_description")
     if (description) return description
     const code = hashParams.get("error_code") ?? searchParams.get("error_code")
     if (code) return code
-    const error = hashParams.get("error") ?? searchParams.get("error")
-    return error
+    return hashParams.get("error") ?? searchParams.get("error")
 }
 
 export function PasswordRecoveryScreen() {
-    const { loading: authLoading, isPasswordRecovery, session, updatePassword } = useAuth()
+    const {
+        loading: authLoading,
+        isPasswordRecovery,
+        session,
+        updatePassword,
+    } = useAuth()
     const navigate = useNavigate()
+
     const [password, setPassword] = useState("")
     const [confirmPassword, setConfirmPassword] = useState("")
-    const [error, setError] = useState("")
+    const [showPassword, setShowPassword] = useState(false)
+    const [showConfirm, setShowConfirm] = useState(false)
+    const [confirmTouched, setConfirmTouched] = useState(false)
+    const [submitError, setSubmitError] = useState("")
     const [success, setSuccess] = useState(false)
     const [isSubmitting, setIsSubmitting] = useState(false)
-    const linkError = useMemo(() => (authLoading || success ? null : getLinkErrorFromUrl()), [authLoading, success])
+    const [countdown, setCountdown] = useState(REDIRECT_COUNTDOWN_SECONDS)
+
+    const linkError = useMemo(
+        () => (authLoading || success ? null : getLinkErrorFromUrl()),
+        [authLoading, success],
+    )
+
+    const strength = useMemo(() => evaluateStrength(password), [password])
+    const passwordMeetsMinimum = password.length >= MIN_PASSWORD_LENGTH
+    const confirmMatches =
+        confirmPassword.length > 0 && confirmPassword === password
+    const showConfirmMismatch =
+        confirmTouched &&
+        confirmPassword.length > 0 &&
+        confirmPassword !== password
+    const canSubmit = passwordMeetsMinimum && confirmMatches
+
+    const destination = session ? `/${routes.dashboard}` : `/${routes.login}`
+    const destinationLabel = session ? "dashboard" : "sign-in screen"
 
     useEffect(() => {
         if (!success) return
-        const destination = session ? `/${routes.dashboard}` : `/${routes.login}`
-        const timeout = window.setTimeout(() => navigate(destination, { replace: true }), 1200)
-        return () => window.clearTimeout(timeout)
-    }, [success, session, navigate])
-
-    function handlePasswordChange(event: ChangeEvent<HTMLInputElement>) {
-        setPassword(event.target.value)
-    }
-
-    function handleConfirmPasswordChange(event: ChangeEvent<HTMLInputElement>) {
-        setConfirmPassword(event.target.value)
-    }
+        if (countdown <= 0) {
+            navigate(destination, { replace: true })
+            return
+        }
+        const id = window.setTimeout(() => setCountdown((c) => c - 1), 1000)
+        return () => window.clearTimeout(id)
+    }, [success, countdown, navigate, destination])
 
     async function handleSubmit(event: FormEvent) {
         event.preventDefault()
-        setError("")
-
-        if (password.length < 6) {
-            setError("Password must be at least 6 characters")
+        if (!canSubmit) {
+            setConfirmTouched(true)
             return
         }
-
-        if (password !== confirmPassword) {
-            setError("Passwords do not match")
-            return
-        }
-
+        setSubmitError("")
         setIsSubmitting(true)
         const { error: updateError } = await updatePassword(password)
-
         if (updateError) {
-            setError(updateError.message)
+            setSubmitError(updateError.message)
             setIsSubmitting(false)
             return
         }
-
         setSuccess(true)
         setIsSubmitting(false)
     }
@@ -77,7 +116,7 @@ export function PasswordRecoveryScreen() {
     if (authLoading) {
         return (
             <AuthLayout>
-                <div className="flex justify-center py-8">
+                <div className="flex items-center justify-center py-10">
                     <Spinner size="lg" />
                 </div>
             </AuthLayout>
@@ -86,85 +125,279 @@ export function PasswordRecoveryScreen() {
 
     if (success) {
         return (
-            <AuthLayout>
-                <div className="space-y-4 text-center">
-                    <h2 className="title-h6">Password updated</h2>
-                    <p className="paragraph-sm text-tertiary">
-                        Your password has been reset successfully. Redirecting you now…
-                    </p>
-                    <Link to={session ? `/${routes.dashboard}` : `/${routes.login}`}>
-                        <Button className="w-full mt-2">
-                            {session ? "Continue to dashboard" : "Back to sign in"}
-                        </Button>
-                    </Link>
+            <AuthLayout step={3} totalSteps={3}>
+                <div className="space-y-5">
+                    <div className="flex justify-center pt-1">
+                        <CheckCircle2
+                            className="size-10 text-brand_secondary"
+                            strokeWidth={1.5}
+                            aria-hidden
+                        />
+                    </div>
+                    <div className="space-y-1.5 text-center">
+                        <h2 className="title-h6">You're all set</h2>
+                        <p className="paragraph-sm text-tertiary">
+                            Your password's been updated. Taking you to the{" "}
+                            {destinationLabel} in{" "}
+                            <span className="text-primary tabular-nums">
+                                {countdown}s
+                            </span>
+                            .
+                        </p>
+                    </div>
+                    <Button
+                        className="w-full"
+                        onClick={() =>
+                            navigate(destination, { replace: true })
+                        }
+                        icon={<ArrowRight />}
+                        iconPosition="trailing"
+                    >
+                        {session
+                            ? "Continue to dashboard"
+                            : "Back to sign in"}
+                    </Button>
                 </div>
             </AuthLayout>
         )
     }
 
     if (!isPasswordRecovery) {
-        const title = linkError ? "This link is no longer valid" : "Recovery link required"
-        const description = linkError
-            ? linkError
-            : "Open the password recovery link from your email to set a new password."
-
         return (
             <AuthLayout>
-                <div className="space-y-4 text-center">
-                    <h2 className="title-h6">{title}</h2>
-                    <p className="paragraph-sm text-tertiary">{description}</p>
-                    <Link to={`/${routes.resetPassword}`}>
-                        <Button variant="secondary" className="w-full mt-2">Request a new link</Button>
-                    </Link>
+                <div className="space-y-5">
+                    <div className="flex justify-center pt-1">
+                        <AlertCircle
+                            className="size-10 text-error"
+                            strokeWidth={1.5}
+                            aria-hidden
+                        />
+                    </div>
+                    <div className="space-y-1.5 text-center">
+                        <h2 className="title-h6">
+                            {linkError
+                                ? "This recovery link won't work"
+                                : "Recovery link required"}
+                        </h2>
+                        <p className="paragraph-sm text-tertiary">
+                            {linkError
+                                ? "Reset links are single-use and short-lived. Common reasons one fails:"
+                                : "Open the most recent password recovery link from your inbox to set a new password."}
+                        </p>
+                    </div>
+
+                    {linkError && (
+                        <ul className="space-y-2.5 paragraph-sm text-tertiary">
+                            <li className="flex gap-2.5">
+                                <span className="text-quaternary mt-[2px]">
+                                    ·
+                                </span>
+                                <span>
+                                    Links can only be used once — older ones
+                                    stop working as soon as a newer one is sent.
+                                </span>
+                            </li>
+                            <li className="flex gap-2.5">
+                                <span className="text-quaternary mt-[2px]">
+                                    ·
+                                </span>
+                                <span>
+                                    They expire shortly after sending. If too
+                                    much time has passed, request a fresh one.
+                                </span>
+                            </li>
+                            <li className="flex gap-2.5">
+                                <span className="text-quaternary mt-[2px]">
+                                    ·
+                                </span>
+                                <span>
+                                    Some email scanners open links
+                                    automatically. Try again from a different
+                                    inbox or device.
+                                </span>
+                            </li>
+                        </ul>
+                    )}
+
+                    <div className="space-y-2 pt-1">
+                        <Link
+                            to={`/${routes.resetPassword}`}
+                            className="block"
+                        >
+                            <Button className="w-full">
+                                Request a new link
+                            </Button>
+                        </Link>
+                        <Link to={`/${routes.login}`} className="block">
+                            <Button variant="ghost" className="w-full">
+                                Back to sign in
+                            </Button>
+                        </Link>
+                    </div>
                 </div>
             </AuthLayout>
         )
     }
 
     return (
-        <AuthLayout>
-            <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="space-y-1">
-                    <h2 className="title-h6">Choose a new password</h2>
+        <AuthLayout step={3} totalSteps={3}>
+            <form onSubmit={handleSubmit} noValidate className="space-y-5">
+                <div className="space-y-1.5">
+                    <h2 className="title-h6">Set a new password</h2>
                     <p className="paragraph-sm text-tertiary">
-                        Enter your new password to complete the recovery flow.
+                        Pick something only you would use. We'll sign you in as
+                        soon as you save.
                     </p>
                 </div>
 
-                {error && (
+                {submitError && (
                     <div className="rounded-lg border border-error bg-error_subtle p-3">
-                        <p className="paragraph-sm text-error">{error}</p>
+                        <p className="paragraph-sm text-error">{submitError}</p>
                     </div>
                 )}
 
-                <div className="space-y-1">
+                <div className="space-y-1.5">
                     <FormLabel label="New password" required />
-                    <Input
-                        type="password"
-                        placeholder="At least 6 characters"
-                        icon={<Lock />}
+                    <PasswordField
                         value={password}
-                        onChange={handlePasswordChange}
-                        required
+                        onChange={setPassword}
+                        visible={showPassword}
+                        onToggleVisible={() =>
+                            setShowPassword((v) => !v)
+                        }
+                        placeholder={`At least ${MIN_PASSWORD_LENGTH} characters`}
+                        autoFocus
+                        autoComplete="new-password"
                     />
+                    {password.length > 0 && (
+                        <StrengthMeter
+                            strength={strength}
+                            tooShort={!passwordMeetsMinimum}
+                        />
+                    )}
                 </div>
 
-                <div className="space-y-1">
+                <div className="space-y-1.5">
                     <FormLabel label="Confirm password" required />
-                    <Input
-                        type="password"
-                        placeholder="Re-enter your password"
-                        icon={<Lock />}
+                    <PasswordField
                         value={confirmPassword}
-                        onChange={handleConfirmPasswordChange}
-                        required
+                        onChange={setConfirmPassword}
+                        visible={showConfirm}
+                        onToggleVisible={() => setShowConfirm((v) => !v)}
+                        onBlur={() => setConfirmTouched(true)}
+                        placeholder="Re-enter your new password"
+                        autoComplete="new-password"
                     />
+                    {showConfirmMismatch && (
+                        <p className="paragraph-xs text-error">
+                            These passwords don't match yet.
+                        </p>
+                    )}
                 </div>
 
-                <Button type="submit" disabled={isSubmitting} className="w-full">
-                    {isSubmitting ? "Updating password..." : "Update password"}
+                <Button
+                    type="submit"
+                    disabled={isSubmitting || !canSubmit}
+                    className="w-full"
+                >
+                    {isSubmitting ? "Saving your password…" : "Save password"}
                 </Button>
             </form>
         </AuthLayout>
+    )
+}
+
+type PasswordFieldProps = {
+    value: string
+    onChange: (next: string) => void
+    onBlur?: () => void
+    visible: boolean
+    onToggleVisible: () => void
+    placeholder?: string
+    autoFocus?: boolean
+    autoComplete?: string
+}
+
+function PasswordField({
+    value,
+    onChange,
+    onBlur,
+    visible,
+    onToggleVisible,
+    placeholder,
+    autoFocus,
+    autoComplete,
+}: PasswordFieldProps) {
+    return (
+        <div className="relative">
+            <Input
+                type={visible ? "text" : "password"}
+                icon={<Lock />}
+                value={value}
+                onChange={(e) => onChange(e.target.value)}
+                onBlur={onBlur}
+                placeholder={placeholder}
+                autoComplete={autoComplete}
+                autoFocus={autoFocus}
+                className="pr-10"
+                required
+            />
+            <button
+                type="button"
+                onClick={onToggleVisible}
+                aria-label={visible ? "Hide password" : "Show password"}
+                aria-pressed={visible}
+                className="absolute inset-y-0 right-3 flex items-center text-tertiary hover:text-secondary transition-colors"
+            >
+                {visible ? (
+                    <EyeOff className="size-4" />
+                ) : (
+                    <Eye className="size-4" />
+                )}
+            </button>
+        </div>
+    )
+}
+
+function StrengthMeter({
+    strength,
+    tooShort,
+}: {
+    strength: Strength
+    tooShort: boolean
+}) {
+    const filled =
+        strength === "weak" ? 1 : strength === "medium" ? 2 : 3
+    const label =
+        strength === "weak" ? "Weak" : strength === "medium" ? "OK" : "Strong"
+    const hint = tooShort
+        ? `Keep going — minimum is ${MIN_PASSWORD_LENGTH} characters.`
+        : strength === "medium"
+          ? "Looking good. Mix in numbers or symbols to make it stronger."
+          : null
+    return (
+        <div className="space-y-1 pt-1">
+            <div className="flex items-center gap-2">
+                <div className="flex flex-1 gap-1">
+                    {[1, 2, 3].map((i) => (
+                        <span
+                            key={i}
+                            className={cn(
+                                "h-1 flex-1 rounded-full transition-colors duration-300",
+                                i <= filled
+                                    ? "bg-brand_solid"
+                                    : "bg-quaternary",
+                            )}
+                        />
+                    ))}
+                </div>
+                <span className="label-xs text-tertiary whitespace-nowrap">
+                    {label}
+                </span>
+            </div>
+            {hint && (
+                <p className="paragraph-xs text-tertiary">{hint}</p>
+            )}
+        </div>
     )
 }

--- a/src/screens/auth/password-recovery.tsx
+++ b/src/screens/auth/password-recovery.tsx
@@ -1,6 +1,6 @@
-import { useMemo, useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import type { ChangeEvent, FormEvent } from "react"
-import { Link } from "react-router-dom"
+import { Link, useNavigate } from "react-router-dom"
 import { Lock } from "lucide-react"
 import { Button } from "@/components/controls/button"
 import { Spinner } from "@/components/feedback/spinner"
@@ -24,12 +24,20 @@ function getLinkErrorFromUrl(): string | null {
 
 export function PasswordRecoveryScreen() {
     const { loading: authLoading, isPasswordRecovery, session, updatePassword } = useAuth()
+    const navigate = useNavigate()
     const [password, setPassword] = useState("")
     const [confirmPassword, setConfirmPassword] = useState("")
     const [error, setError] = useState("")
     const [success, setSuccess] = useState(false)
     const [isSubmitting, setIsSubmitting] = useState(false)
-    const linkError = useMemo(() => (authLoading ? null : getLinkErrorFromUrl()), [authLoading])
+    const linkError = useMemo(() => (authLoading || success ? null : getLinkErrorFromUrl()), [authLoading, success])
+
+    useEffect(() => {
+        if (!success) return
+        const destination = session ? `/${routes.dashboard}` : `/${routes.login}`
+        const timeout = window.setTimeout(() => navigate(destination, { replace: true }), 1200)
+        return () => window.clearTimeout(timeout)
+    }, [success, session, navigate])
 
     function handlePasswordChange(event: ChangeEvent<HTMLInputElement>) {
         setPassword(event.target.value)
@@ -76,6 +84,24 @@ export function PasswordRecoveryScreen() {
         )
     }
 
+    if (success) {
+        return (
+            <AuthLayout>
+                <div className="space-y-4 text-center">
+                    <h2 className="title-h6">Password updated</h2>
+                    <p className="paragraph-sm text-tertiary">
+                        Your password has been reset successfully. Redirecting you now…
+                    </p>
+                    <Link to={session ? `/${routes.dashboard}` : `/${routes.login}`}>
+                        <Button className="w-full mt-2">
+                            {session ? "Continue to dashboard" : "Back to sign in"}
+                        </Button>
+                    </Link>
+                </div>
+            </AuthLayout>
+        )
+    }
+
     if (!isPasswordRecovery) {
         const title = linkError ? "This link is no longer valid" : "Recovery link required"
         const description = linkError
@@ -89,24 +115,6 @@ export function PasswordRecoveryScreen() {
                     <p className="paragraph-sm text-tertiary">{description}</p>
                     <Link to={`/${routes.resetPassword}`}>
                         <Button variant="secondary" className="w-full mt-2">Request a new link</Button>
-                    </Link>
-                </div>
-            </AuthLayout>
-        )
-    }
-
-    if (success) {
-        return (
-            <AuthLayout>
-                <div className="space-y-4 text-center">
-                    <h2 className="title-h6">Password updated</h2>
-                    <p className="paragraph-sm text-tertiary">
-                        Your password has been reset successfully.
-                    </p>
-                    <Link to={session ? `/${routes.dashboard}` : `/${routes.login}`}>
-                        <Button className="w-full mt-2">
-                            {session ? "Continue to dashboard" : "Back to sign in"}
-                        </Button>
                     </Link>
                 </div>
             </AuthLayout>

--- a/src/screens/auth/reset-password.tsx
+++ b/src/screens/auth/reset-password.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react"
-import type { ChangeEvent, FormEvent } from "react"
+import type { FormEvent } from "react"
 import { Link } from "react-router-dom"
-import { Mail } from "lucide-react"
+import { ArrowLeft, Mail, MailCheck } from "lucide-react"
 import { Button } from "@/components/controls/button"
 import { Input } from "@/components/form/input"
 import { FormLabel } from "@/components/form/form-label"
@@ -9,58 +9,112 @@ import { useAuth } from "@/lib/auth-context"
 import { routes } from "@/screens/console-routes"
 import { AuthLayout } from "./auth-layout"
 
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
 export function ResetPasswordScreen() {
     const { resetPassword } = useAuth()
     const [email, setEmail] = useState("")
+    const [emailTouched, setEmailTouched] = useState(false)
+    const [submittedEmail, setSubmittedEmail] = useState<string | null>(null)
     const [error, setError] = useState("")
-    const [success, setSuccess] = useState(false)
     const [isSubmitting, setIsSubmitting] = useState(false)
 
-    function handleEmailChange(event: ChangeEvent<HTMLInputElement>) {
-        setEmail(event.target.value)
-    }
+    const trimmedEmail = email.trim()
+    const emailIsValid = EMAIL_PATTERN.test(trimmedEmail)
+    const showInlineEmailError =
+        emailTouched && trimmedEmail.length > 0 && !emailIsValid
+    const success = submittedEmail !== null
 
     async function handleSubmit(event: FormEvent) {
         event.preventDefault()
+        if (!emailIsValid) {
+            setEmailTouched(true)
+            return
+        }
         setError("")
         setIsSubmitting(true)
-
-        const { error: resetError } = await resetPassword(email)
-
+        const { error: resetError } = await resetPassword(trimmedEmail)
         if (resetError) {
             setError(resetError.message)
             setIsSubmitting(false)
             return
         }
+        setSubmittedEmail(trimmedEmail)
+        setIsSubmitting(false)
+    }
 
-        setSuccess(true)
+    async function handleResend() {
+        if (!submittedEmail) return
+        setError("")
+        setIsSubmitting(true)
+        const { error: resetError } = await resetPassword(submittedEmail)
+        if (resetError) setError(resetError.message)
         setIsSubmitting(false)
     }
 
     if (success) {
         return (
-            <AuthLayout>
-                <div className="space-y-4 text-center">
-                    <h2 className="title-h6">Check your email</h2>
-                    <p className="paragraph-sm text-tertiary">
-                        If an account exists for <span className="text-primary font-medium">{email}</span>,
-                        you&apos;ll receive a password reset link shortly.
-                    </p>
-                    <Link to={`/${routes.login}`}>
-                        <Button variant="secondary" className="w-full mt-2">Back to sign in</Button>
-                    </Link>
+            <AuthLayout step={2} totalSteps={3}>
+                <div className="space-y-5">
+                    <div className="flex justify-center pt-1">
+                        <MailCheck
+                            className="size-10 text-brand_secondary"
+                            strokeWidth={1.5}
+                            aria-hidden
+                        />
+                    </div>
+                    <div className="space-y-1.5 text-center">
+                        <h2 className="title-h6">Check your inbox</h2>
+                        <p className="paragraph-sm text-tertiary">
+                            If an account exists for{" "}
+                            <span className="text-primary font-medium">
+                                {submittedEmail}
+                            </span>
+                            , a single-use reset link is on its way. Open it on
+                            the same device — the link expires shortly.
+                        </p>
+                    </div>
+
+                    {error && (
+                        <div className="rounded-lg border border-error bg-error_subtle p-3">
+                            <p className="paragraph-sm text-error">{error}</p>
+                        </div>
+                    )}
+
+                    <div className="space-y-2 pt-1">
+                        <Button
+                            variant="secondary"
+                            className="w-full"
+                            onClick={handleResend}
+                            disabled={isSubmitting}
+                        >
+                            {isSubmitting
+                                ? "Sending another link…"
+                                : "Didn't get it? Send again"}
+                        </Button>
+                        <Link to={`/${routes.login}`} className="block">
+                            <Button
+                                variant="ghost"
+                                className="w-full"
+                                icon={<ArrowLeft />}
+                            >
+                                Back to sign in
+                            </Button>
+                        </Link>
+                    </div>
                 </div>
             </AuthLayout>
         )
     }
 
     return (
-        <AuthLayout>
-            <form onSubmit={handleSubmit} className="space-y-4">
-                <div className="space-y-1">
-                    <h2 className="title-h6">Reset password</h2>
+        <AuthLayout step={1} totalSteps={3}>
+            <form onSubmit={handleSubmit} noValidate className="space-y-5">
+                <div className="space-y-1.5">
+                    <h2 className="title-h6">Forgot your password?</h2>
                     <p className="paragraph-sm text-tertiary">
-                        Enter your email and we&apos;ll send you a link to reset your password.
+                        Drop the email tied to your account and we'll send a
+                        single-use link to set a new one.
                     </p>
                 </div>
 
@@ -70,25 +124,41 @@ export function ResetPasswordScreen() {
                     </div>
                 )}
 
-                <div className="space-y-1">
+                <div className="space-y-1.5">
                     <FormLabel label="Email" required />
                     <Input
                         type="email"
-                        placeholder="you@example.com"
+                        placeholder="you@yourchurch.org"
                         icon={<Mail />}
                         value={email}
-                        onChange={handleEmailChange}
+                        onChange={(e) => setEmail(e.target.value)}
+                        onBlur={() => setEmailTouched(true)}
+                        autoComplete="email"
+                        autoFocus
                         required
                     />
+                    {showInlineEmailError && (
+                        <p className="paragraph-xs text-error">
+                            That doesn't look like a valid email — check for
+                            typos.
+                        </p>
+                    )}
                 </div>
 
-                <Button type="submit" disabled={isSubmitting} className="w-full">
-                    {isSubmitting ? "Sending link..." : "Send reset link"}
+                <Button
+                    type="submit"
+                    disabled={isSubmitting || !emailIsValid}
+                    className="w-full"
+                >
+                    {isSubmitting ? "Sending your link…" : "Send reset link"}
                 </Button>
 
                 <p className="paragraph-sm text-center text-tertiary">
-                    Remember your password?{" "}
-                    <Link to={`/${routes.login}`} className="text-brand_secondary hover:underline">
+                    Suddenly remembered it?{" "}
+                    <Link
+                        to={`/${routes.login}`}
+                        className="text-brand_secondary hover:underline"
+                    >
                         Sign in
                     </Link>
                 </p>


### PR DESCRIPTION
## Summary

A two-commit pass on the password-recovery flow. The previous PR was closed, so this one bundles the success-state fix with the broader UX refactor.

**1. Success state fix.** After `updatePassword` succeeded, the `USER_UPDATED` auth event flipped `isPasswordRecovery` to `false` before React re-rendered. Because the screen checked `!isPasswordRecovery` before `success`, users landed back on the generic "Recovery link required" copy instead of seeing the success state. Reorders the branches so success always wins, and adds auto-redirect.

**2. UX refactor — recovery flow only.** Tightens the three screens (`reset-password`, `password-recovery`, shared `auth-layout`) without a visual reinvention. Keeps the existing minimal/typographic feel.

### What's new in the UX

- **3-step progress rail** above the auth card — request → verify → update. New optional `step` / `totalSteps` props on `AuthLayout`, backward-compatible.
- **Inline field-level validation** — email format under the email field; password length and mismatch hints under their own fields. Top banner reserved for backend errors.
- **Show/hide password toggle** on each password field.
- **Strength meter** — three brand-pink segments with Weak / OK / Strong label and contextual hint.
- **Inline success state** on recovery — checkmark, live redirect countdown, primary Continue CTA that skips the timer.
- **Expired/invalid link state** — lists the three common causes (already used, expired, scanner pre-fetch) with a single bold "Request a new link" action.
- **Tightened copy** throughout — confident, MOC-flavored, no more "Loading..." or generic placeholders.

Login and signup screens are intentionally untouched.

## Test plan

- [ ] `/reset-password` → submit a valid email → progress rail advances from step 1 to step 2, "Check your inbox" state appears with the email rendered inline
- [ ] On the success state, "Send again" button works and disables while in flight
- [ ] Submit an invalid email → inline validation under the field (no top banner)
- [ ] Click the reset link from email → land on `/password-recovery` with progress rail at step 3 and the "Set a new password" form
- [ ] Type a short password → "Weak" + "Keep going" hint under the meter
- [ ] Type a stronger password → meter advances through OK → Strong
- [ ] Mismatched confirm → inline error under the confirm field after blur
- [ ] Click the eye icon → password text toggles visibility on each field independently
- [ ] Submit valid passwords → inline success state on the same screen with a 4s countdown
- [ ] Click "Continue to dashboard" mid-countdown → navigates immediately
- [ ] Land on `/password-recovery` with no token → "Recovery link required" copy + "Request a new link" CTA
- [ ] Land on `/password-recovery` with `?error_code=otp_expired` in URL → "This recovery link won't work" with reason list

🤖 Generated with [Claude Code](https://claude.com/claude-code)