### PR TITLE
Monorepo: reunify console + request, extract shared @moc/* packages

### DIFF
--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -1,6 +1,12 @@
 @import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&display=swap');
 @import "tailwindcss";
 
+/* Tailwind v4 auto-detects sources from the Vite project root (the consuming
+   app), which excludes this workspace package. Without these @source globs,
+   classes used in @moc/ui components (e.g. the sidebar's area-sidebar,
+   w-sidebar, app-grid-desktop) never reach the built CSS and break layout. */
+@source "./**/*.{ts,tsx}";
+
 @theme {
   --breakpoint-mobile: 480px;
 }


### PR DESCRIPTION
## Summary

- Restructure the repo into a bun-workspaces monorepo: `apps/{console,request}` + `packages/{ui,data,utils,types}`.
- Bring `moc-request` back in as `apps/request` via `git subtree`, then rewire both apps to import shared primitives from `@moc/ui`, `@moc/data`, `@moc/utils`, and `@moc/types` instead of duplicating them.
- Fix package boundary leaks so the request app uses canonical primitives from `@moc/ui` and stops shadowing them locally.
- Fix Tailwind v4 in the monorepo: add `@source` to `packages/ui/src/index.css` so classes used inside `@moc/ui` components (sidebar grid area, width tokens, `md:app-grid-desktop`, arbitrary-value utilities, etc.) actually reach the built CSS. Without this the desktop console layout collapsed because the relevant rules were silently dropped.
- Consolidate docs (`CONTEXT.md`, `AGENTS.md`, `docs/adr/`) at the workspace root, restore the env example, and drop scripts that no longer apply.

## Test plan

- [ ] `bun --filter moc-console build` succeeds; `dist/assets/index-*.css` contains `area-sidebar`, `w-sidebar`, `w-sidebar-collapsed`, and `md\\:app-grid-desktop`.
- [ ] `bun --filter moc-request build` succeeds and produces a styled bundle.
- [ ] `bun --filter moc-console dev` — log in and walk the dashboard, requests, equipment, broadcast, and cue-sheet screens; sidebar + topbar grid render correctly at desktop and mobile widths.
- [ ] `bun --filter moc-request dev` — Make Request, Book Equipment, and Track Submission flows render and submit.
- [ ] No import cycles between apps and packages; nothing inside `packages/*` reaches up into `apps/*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)