### PR TITLE
Broadcast & notifications: YouTube token health, safe delete ordering, message templates

### DIFF
--- a/apps/console/api/notifications/assignment.ts
+++ b/apps/console/api/notifications/assignment.ts
@@ -3,6 +3,11 @@ import { sendTelegramMessage } from "../../server/telegram.js"
 import { requireAuthenticatedUser, AuthError } from "../../server/auth-guard.js"
 import { resolveTemplate } from "../../server/notifications/templates.js"
 import {
+  enrichRequest,
+  enrichCue,
+  enrichChecklistItem,
+} from "../../server/notifications/enrich.js"
+import {
   renderTemplate,
   type DmMessageType,
   type TokenValues,
@@ -68,15 +73,16 @@ async function buildRequest(
   const admin = getSupabaseAdmin()
   const { data } = await admin
     .from("requests")
-    .select("title, workspace_id")
+    .select("workspace_id")
     .eq("id", parentId)
     .maybeSingle()
   if (!data) return null
+  const enriched = await enrichRequest(parentId)
   return {
     workspaceId: data.workspace_id,
     messageType: "assignment.request",
     tokens: {
-      title: data.title,
+      ...enriched,
       duty,
       assigneeName,
       linkUrl: `${baseUrl}/requests/${parentId}`,
@@ -90,25 +96,15 @@ async function buildCue(
   assigneeName: string,
   baseUrl: string,
 ): Promise<Resolved | null> {
+  const enriched = await enrichCue(parentId)
+  if (!enriched || !enriched.eventId) return null
+  const { eventId, ...tokens } = enriched
+
   const admin = getSupabaseAdmin()
-  const { data: cue } = await admin
-    .from("cues")
-    .select("label, track_id")
-    .eq("id", parentId)
-    .maybeSingle()
-  if (!cue) return null
-
-  const { data: track } = await admin
-    .from("tracks")
-    .select("event_id")
-    .eq("id", cue.track_id)
-    .maybeSingle()
-  if (!track) return null
-
   const { data: event } = await admin
     .from("events")
-    .select("id, title, workspace_id")
-    .eq("id", track.event_id)
+    .select("workspace_id")
+    .eq("id", eventId)
     .maybeSingle()
   if (!event) return null
 
@@ -116,11 +112,10 @@ async function buildCue(
     workspaceId: event.workspace_id,
     messageType: "assignment.cue",
     tokens: {
-      title: cue.label,
-      eventName: event.title,
+      ...tokens,
       duty,
       assigneeName,
-      linkUrl: `${baseUrl}/cue-sheet/events/${event.id}`,
+      linkUrl: `${baseUrl}/cue-sheet/events/${eventId}`,
     },
   }
 }
@@ -131,18 +126,15 @@ async function buildChecklistItem(
   assigneeName: string,
   baseUrl: string,
 ): Promise<Resolved | null> {
-  const admin = getSupabaseAdmin()
-  const { data: item } = await admin
-    .from("checklist_items")
-    .select("label, checklist_id")
-    .eq("id", parentId)
-    .maybeSingle()
-  if (!item) return null
+  const enriched = await enrichChecklistItem(parentId)
+  if (!enriched || !enriched.checklistId) return null
+  const { checklistId, ...tokens } = enriched
 
+  const admin = getSupabaseAdmin()
   const { data: checklist } = await admin
     .from("checklists")
-    .select("id, name, workspace_id")
-    .eq("id", item.checklist_id)
+    .select("workspace_id")
+    .eq("id", checklistId)
     .maybeSingle()
   if (!checklist) return null
 
@@ -150,11 +142,10 @@ async function buildChecklistItem(
     workspaceId: checklist.workspace_id,
     messageType: "assignment.checklist_item",
     tokens: {
-      title: item.label,
-      checklistName: checklist.name,
+      ...tokens,
       duty,
       assigneeName,
-      linkUrl: `${baseUrl}/cue-sheet/checklist/${checklist.id}`,
+      linkUrl: `${baseUrl}/cue-sheet/checklist/${checklistId}`,
     },
   }
 }

--- a/apps/console/api/notifications/assignment.ts
+++ b/apps/console/api/notifications/assignment.ts
@@ -235,7 +235,8 @@ export default async function handler(request: ApiRequest, response: ApiResponse
 
   await sendTelegramMessage(user.telegram_chat_id, text, {
     parseMode: "HTML",
-    disableLinkPreview: true,
+    // Link preview left enabled so the assignee gets a rich preview of
+    // the link, even though its URL is hidden inside the <a> tag.
   })
   response.status(200).json({ ok: true })
 }

--- a/apps/console/api/notifications/assignment.ts
+++ b/apps/console/api/notifications/assignment.ts
@@ -1,6 +1,12 @@
 import { getSupabaseAdmin } from "../../server/supabase-admin.js"
 import { sendTelegramMessage } from "../../server/telegram.js"
 import { requireAuthenticatedUser, AuthError } from "../../server/auth-guard.js"
+import { resolveTemplate } from "../../server/notifications/templates.js"
+import {
+  renderTemplate,
+  type DmMessageType,
+  type TokenValues,
+} from "../../src/data/notification-templates-core.js"
 
 type ApiRequest = {
   method?: string
@@ -42,63 +48,48 @@ function resolveBaseUrl(): string | null {
   return null
 }
 
-// Telegram's HTML parser only special-cases &, <, > — quotes don't need escaping.
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
+// Each builder resolves the parent resource (which also yields the
+// workspace the template lookup is keyed by) and returns the flat
+// {{token}} values. Returns null when the parent is gone, preserving
+// the old "skipped: parent_not_found" path. Token names must match
+// TEMPLATE_TOKENS in the core.
+type Resolved = {
+  workspaceId: string
+  messageType: DmMessageType
+  tokens: TokenValues
 }
 
-function buildMessage(args: {
-  heading: string
-  title: string
-  context?: { label: string; value: string }
-  duty: string
-  linkUrl: string
-  linkLabel: string
-}): string {
-  const lines: string[] = []
-  lines.push(`<b>${args.heading}</b>`)
-  lines.push("")
-  lines.push(escapeHtml(args.title))
-  if (args.context) {
-    lines.push(`${args.context.label}: ${escapeHtml(args.context.value)}`)
-  }
-  if (args.duty) {
-    lines.push(`Duty: <i>${escapeHtml(args.duty)}</i>`)
-  }
-  lines.push("")
-  lines.push(`<a href="${args.linkUrl}">${args.linkLabel}</a>`)
-  return lines.join("\n")
-}
-
-async function buildRequestMessage(
+async function buildRequest(
   parentId: string,
   duty: string,
+  assigneeName: string,
   baseUrl: string,
-): Promise<string | null> {
+): Promise<Resolved | null> {
   const admin = getSupabaseAdmin()
   const { data } = await admin
     .from("requests")
-    .select("title")
+    .select("title, workspace_id")
     .eq("id", parentId)
     .maybeSingle()
   if (!data) return null
-  return buildMessage({
-    heading: "You've been assigned to a request",
-    title: data.title,
-    duty,
-    linkUrl: `${baseUrl}/requests/${parentId}`,
-    linkLabel: "Open request",
-  })
+  return {
+    workspaceId: data.workspace_id,
+    messageType: "assignment.request",
+    tokens: {
+      title: data.title,
+      duty,
+      assigneeName,
+      linkUrl: `${baseUrl}/requests/${parentId}`,
+    },
+  }
 }
 
-async function buildCueMessage(
+async function buildCue(
   parentId: string,
   duty: string,
+  assigneeName: string,
   baseUrl: string,
-): Promise<string | null> {
+): Promise<Resolved | null> {
   const admin = getSupabaseAdmin()
   const { data: cue } = await admin
     .from("cues")
@@ -116,26 +107,30 @@ async function buildCueMessage(
 
   const { data: event } = await admin
     .from("events")
-    .select("id, name")
+    .select("id, title, workspace_id")
     .eq("id", track.event_id)
     .maybeSingle()
   if (!event) return null
 
-  return buildMessage({
-    heading: "You've been assigned to a cue",
-    title: cue.label,
-    context: { label: "Event", value: event.name },
-    duty,
-    linkUrl: `${baseUrl}/cue-sheet/events/${event.id}`,
-    linkLabel: "Open event",
-  })
+  return {
+    workspaceId: event.workspace_id,
+    messageType: "assignment.cue",
+    tokens: {
+      title: cue.label,
+      eventName: event.title,
+      duty,
+      assigneeName,
+      linkUrl: `${baseUrl}/cue-sheet/events/${event.id}`,
+    },
+  }
 }
 
-async function buildChecklistItemMessage(
+async function buildChecklistItem(
   parentId: string,
   duty: string,
+  assigneeName: string,
   baseUrl: string,
-): Promise<string | null> {
+): Promise<Resolved | null> {
   const admin = getSupabaseAdmin()
   const { data: item } = await admin
     .from("checklist_items")
@@ -146,19 +141,22 @@ async function buildChecklistItemMessage(
 
   const { data: checklist } = await admin
     .from("checklists")
-    .select("id, name")
+    .select("id, name, workspace_id")
     .eq("id", item.checklist_id)
     .maybeSingle()
   if (!checklist) return null
 
-  return buildMessage({
-    heading: "You've been assigned to a checklist item",
-    title: item.label,
-    context: { label: "Checklist", value: checklist.name },
-    duty,
-    linkUrl: `${baseUrl}/cue-sheet/checklist/${checklist.id}`,
-    linkLabel: "Open checklist",
-  })
+  return {
+    workspaceId: checklist.workspace_id,
+    messageType: "assignment.checklist_item",
+    tokens: {
+      title: item.label,
+      checklistName: checklist.name,
+      duty,
+      assigneeName,
+      linkUrl: `${baseUrl}/cue-sheet/checklist/${checklist.id}`,
+    },
+  }
 }
 
 export default async function handler(request: ApiRequest, response: ApiResponse) {
@@ -210,7 +208,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
   const admin = getSupabaseAdmin()
   const { data: user } = await admin
     .from("users")
-    .select("telegram_chat_id")
+    .select("telegram_chat_id, name, surname")
     .eq("id", userId)
     .maybeSingle()
 
@@ -219,25 +217,30 @@ export default async function handler(request: ApiRequest, response: ApiResponse
     return
   }
 
+  const assigneeName = [user.name, user.surname].filter(Boolean).join(" ").trim()
+
   const baseUrl = resolveBaseUrl()
   if (!baseUrl) {
     response.status(200).json({ ok: true, skipped: "no_base_url" })
     return
   }
 
-  let text: string | null = null
+  let resolved: Resolved | null = null
   if (kind === "request") {
-    text = await buildRequestMessage(parentId, duty, baseUrl)
+    resolved = await buildRequest(parentId, duty, assigneeName, baseUrl)
   } else if (kind === "cue") {
-    text = await buildCueMessage(parentId, duty, baseUrl)
+    resolved = await buildCue(parentId, duty, assigneeName, baseUrl)
   } else {
-    text = await buildChecklistItemMessage(parentId, duty, baseUrl)
+    resolved = await buildChecklistItem(parentId, duty, assigneeName, baseUrl)
   }
 
-  if (!text) {
+  if (!resolved) {
     response.status(200).json({ ok: true, skipped: "parent_not_found" })
     return
   }
+
+  const template = await resolveTemplate(resolved.workspaceId, "dm", resolved.messageType)
+  const text = renderTemplate(template, resolved.tokens)
 
   await sendTelegramMessage(user.telegram_chat_id, text, {
     parseMode: "HTML",

--- a/apps/console/api/notifications/bookings.ts
+++ b/apps/console/api/notifications/bookings.ts
@@ -19,6 +19,7 @@ type BookingEventType = "booking.created" | "booking.status_changed"
 type Body = {
   event_type?: string
   workspace_id?: string
+  tracking_code?: string | null
   title?: string
   status?: string | null
   requester_name?: string | null
@@ -87,6 +88,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
   }
 
   const requesterName = typeof body.requester_name === "string" ? body.requester_name : null
+  const trackingCode = typeof body.tracking_code === "string" ? body.tracking_code : null
 
   let result: { attempted: number; succeeded: number }
   if (event_type === "booking.status_changed") {
@@ -98,6 +100,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
       title,
       status: body.status,
       linkUrl: link_url,
+      trackingCode,
     })
   } else {
     result = await dispatchEvent(workspace_id, "booking.created", {
@@ -105,6 +108,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
       status: typeof body.status === "string" ? body.status : null,
       requesterName,
       linkUrl: link_url,
+      trackingCode,
     })
   }
 

--- a/apps/console/api/notifications/internal/meeting-created.ts
+++ b/apps/console/api/notifications/internal/meeting-created.ts
@@ -79,6 +79,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
     topic: row.topic,
     startTime: row.start_time,
     joinUrl: row.join_url,
+    meetingId: row.id,
   })
 
   response.status(200).json({ ok: true, ...result })

--- a/apps/console/api/notifications/internal/stream-created.ts
+++ b/apps/console/api/notifications/internal/stream-created.ts
@@ -80,6 +80,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
     title: row.title,
     scheduledStartTime: row.scheduled_start_time,
     streamUrl: row.stream_url,
+    streamId: row.id,
   })
 
   response.status(200).json({ ok: true, ...result })

--- a/apps/console/api/notifications/requests.ts
+++ b/apps/console/api/notifications/requests.ts
@@ -22,6 +22,7 @@ type RequestEventType =
 type Body = {
   event_type?: string
   workspace_id?: string
+  request_id?: string | null
   title?: string
   status?: string | null
   requester_name?: string | null
@@ -94,6 +95,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
   }
 
   const requesterName = typeof body.requester_name === "string" ? body.requester_name : null
+  const requestId = typeof body.request_id === "string" ? body.request_id : null
 
   let result: { attempted: number; succeeded: number }
   if (event_type === "request.status_changed") {
@@ -106,12 +108,14 @@ export default async function handler(request: ApiRequest, response: ApiResponse
       status: body.status,
       requesterName,
       linkUrl: link_url,
+      requestId,
     })
   } else if (event_type === "request.archived") {
     result = await dispatchEvent(workspace_id, event_type as RequestEventType, {
       title,
       requesterName,
       linkUrl: link_url,
+      requestId,
     })
   } else {
     result = await dispatchEvent(workspace_id, "request.created", {
@@ -119,6 +123,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
       status: typeof body.status === "string" ? body.status : null,
       requesterName,
       linkUrl: link_url,
+      requestId,
     })
   }
 

--- a/apps/console/api/youtube/oauth/refresh.ts
+++ b/apps/console/api/youtube/oauth/refresh.ts
@@ -1,4 +1,4 @@
-import { refreshYouTubeToken, resolveYouTubeOAuthConfig } from "../../../server/youtube-oauth.js"
+import { refreshYouTubeToken, resolveYouTubeOAuthConfig, YouTubeReauthRequiredError } from "../../../server/youtube-oauth.js"
 import { AuthError, requireAuthenticatedUser } from "../../../server/auth-guard.js"
 
 type ApiRequest = {
@@ -49,7 +49,14 @@ export default async function handler(request: ApiRequest, response: ApiResponse
     const result = await refreshYouTubeToken(config, refreshTokenValue)
     response.status(200).json(result)
   } catch (error) {
+    if (error instanceof YouTubeReauthRequiredError) {
+      // Refresh token is permanently dead — the client must persist
+      // reauth_required and prompt a reconnect. Not retryable.
+      response.status(401).json({ error: error.message, code: "reauth_required" })
+      return
+    }
+    // Transient failure (network, Google 5xx). Safe to retry later.
     console.error("YouTube token refresh failed:", error)
-    response.status(500).json({ error: "YouTube token refresh failed" })
+    response.status(502).json({ error: "YouTube token refresh failed" })
   }
 }

--- a/apps/console/server/notifications/dispatch.ts
+++ b/apps/console/server/notifications/dispatch.ts
@@ -250,7 +250,9 @@ export async function dispatchEvent<K extends NotificationEventKey>(
   for (const route of routes) {
     const send = await sendTelegramMessageDetailed(route.group_chat_id, text, {
       parseMode: "HTML",
-      disableLinkPreview: true,
+      // Link preview left enabled: the action link lives inside an <a>
+      // tag, and Telegram previews the first link in the message so the
+      // recipient sees a rich preview of where it goes.
       ...(route.thread_id !== null ? { threadId: route.thread_id } : {}),
     })
 

--- a/apps/console/server/notifications/dispatch.ts
+++ b/apps/console/server/notifications/dispatch.ts
@@ -4,6 +4,11 @@ import {
   isNotificationEventKey,
   type NotificationEventKey,
 } from "../../src/data/notification-events.js"
+import {
+  renderTemplate,
+  type TokenValues,
+} from "../../src/data/notification-templates-core.js"
+import { resolveTemplate } from "./templates.js"
 
 export type StreamCreatedPayload = {
   title: string
@@ -67,14 +72,6 @@ type RouteRow = {
   telegram_groups: { active: boolean; removed_at: string | null } | null
 }
 
-// Telegram HTML parser only special-cases &, <, >.
-function escapeHtml(text: string): string {
-  return text
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-}
-
 function formatScheduled(scheduled: string | null): string | null {
   if (!scheduled) return null
   const date = new Date(scheduled)
@@ -82,73 +79,52 @@ function formatScheduled(scheduled: string | null): string | null {
   return date.toUTCString()
 }
 
-function buildMessage<K extends NotificationEventKey>(
+// Flatten a payload into the {{token}} values the renderer substitutes.
+// Date/URL derivation lives here; escaping + line-collapse is the
+// renderer's job. Token names must match TEMPLATE_TOKENS in the core.
+function buildTokens<K extends NotificationEventKey>(
   eventType: K,
   payload: EventPayloadMap[K],
-): string {
+): TokenValues {
   switch (eventType) {
     case "stream.created": {
       const p = payload as StreamCreatedPayload
-      const lines: string[] = [`<b>New YouTube stream</b>`, "", escapeHtml(p.title)]
-      const when = formatScheduled(p.scheduledStartTime)
-      if (when) lines.push(`Scheduled for ${escapeHtml(when)}`)
-      if (p.streamUrl) lines.push("", `<a href="${p.streamUrl}">Open stream</a>`)
-      return lines.join("\n")
+      return {
+        title: p.title,
+        scheduledStartTime: formatScheduled(p.scheduledStartTime),
+        streamUrl: p.streamUrl,
+      }
     }
     case "meeting.created": {
       const p = payload as MeetingCreatedPayload
-      const lines: string[] = [`<b>New Zoom meeting</b>`, "", escapeHtml(p.topic)]
-      const when = formatScheduled(p.startTime)
-      if (when) lines.push(`Scheduled for ${escapeHtml(when)}`)
-      if (p.joinUrl) lines.push("", `<a href="${p.joinUrl}">Join meeting</a>`)
-      return lines.join("\n")
+      return {
+        topic: p.topic,
+        startTime: formatScheduled(p.startTime),
+        joinUrl: p.joinUrl,
+      }
     }
     case "request.created": {
       const p = payload as RequestCreatedPayload
-      const lines: string[] = [`<b>New request</b>`, "", escapeHtml(p.title)]
-      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
-      if (p.status) lines.push(`Status: <i>${escapeHtml(p.status)}</i>`)
-      lines.push("", `<a href="${p.linkUrl}">Open request</a>`)
-      return lines.join("\n")
+      return { title: p.title, status: p.status, requesterName: p.requesterName, linkUrl: p.linkUrl }
     }
     case "request.status_changed": {
       const p = payload as RequestStatusChangedPayload
-      const lines: string[] = [
-        `<b>Request status updated</b>`,
-        "",
-        escapeHtml(p.title),
-        `Status: <i>${escapeHtml(p.status)}</i>`,
-      ]
-      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
-      lines.push("", `<a href="${p.linkUrl}">Open request</a>`)
-      return lines.join("\n")
+      return { title: p.title, status: p.status, requesterName: p.requesterName, linkUrl: p.linkUrl }
     }
     case "request.archived": {
       const p = payload as RequestArchivedPayload
-      const lines: string[] = [`<b>Request archived</b>`, "", escapeHtml(p.title)]
-      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
-      lines.push("", `<a href="${p.linkUrl}">Open request</a>`)
-      return lines.join("\n")
+      return { title: p.title, requesterName: p.requesterName, linkUrl: p.linkUrl }
     }
     case "booking.created": {
       const p = payload as BookingCreatedPayload
-      const lines: string[] = [`<b>New equipment booking</b>`, "", escapeHtml(p.title)]
-      if (p.requesterName) lines.push(`From: ${escapeHtml(p.requesterName)}`)
-      if (p.status) lines.push(`Status: <i>${escapeHtml(p.status)}</i>`)
-      lines.push("", `<a href="${p.linkUrl}">Open booking</a>`)
-      return lines.join("\n")
+      return { title: p.title, status: p.status, requesterName: p.requesterName, linkUrl: p.linkUrl }
     }
     case "booking.status_changed": {
       const p = payload as BookingStatusChangedPayload
-      return [
-        `<b>Equipment booking updated</b>`,
-        "",
-        escapeHtml(p.title),
-        `Status: <i>${escapeHtml(p.status)}</i>`,
-        "",
-        `<a href="${p.linkUrl}">Open booking</a>`,
-      ].join("\n")
+      return { title: p.title, status: p.status, linkUrl: p.linkUrl }
     }
+    default:
+      return {}
   }
 }
 
@@ -223,7 +199,10 @@ export async function dispatchEvent<K extends NotificationEventKey>(
 
   if (routes.length === 0) return { attempted: 0, succeeded: 0 }
 
-  const text = buildMessage(eventType, payload)
+  // One template lookup per dispatch (shared across all routes), then
+  // fall back to the hardcoded default when no custom row is set.
+  const template = await resolveTemplate(workspaceId, "group", eventType)
+  const text = renderTemplate(template, buildTokens(eventType, payload))
   let succeeded = 0
 
   for (const route of routes) {

--- a/apps/console/server/notifications/dispatch.ts
+++ b/apps/console/server/notifications/dispatch.ts
@@ -9,17 +9,29 @@ import {
   type TokenValues,
 } from "../../src/data/notification-templates-core.js"
 import { resolveTemplate } from "./templates.js"
+import {
+  enrichBooking,
+  enrichRequest,
+  enrichStream,
+  enrichMeeting,
+} from "./enrich.js"
+
+// The optional *Id / trackingCode fields drive DB enrichment (rich
+// composable tokens). They're optional so older/external senders that
+// omit them still work — the scalar payload fields are the fallback.
 
 export type StreamCreatedPayload = {
   title: string
   scheduledStartTime: string | null
   streamUrl: string | null
+  streamId?: string
 }
 
 export type MeetingCreatedPayload = {
   topic: string
   startTime: string | null
   joinUrl: string | null
+  meetingId?: string
 }
 
 export type RequestCreatedPayload = {
@@ -27,6 +39,7 @@ export type RequestCreatedPayload = {
   status: string | null
   requesterName: string | null
   linkUrl: string
+  requestId?: string | null
 }
 
 export type RequestStatusChangedPayload = {
@@ -34,12 +47,14 @@ export type RequestStatusChangedPayload = {
   status: string
   requesterName?: string | null
   linkUrl: string
+  requestId?: string | null
 }
 
 export type RequestArchivedPayload = {
   title: string
   requesterName?: string | null
   linkUrl: string
+  requestId?: string | null
 }
 
 export type BookingCreatedPayload = {
@@ -47,12 +62,14 @@ export type BookingCreatedPayload = {
   status?: string | null
   requesterName?: string | null
   linkUrl: string
+  trackingCode?: string | null
 }
 
 export type BookingStatusChangedPayload = {
   title: string
   status: string
   linkUrl: string
+  trackingCode?: string | null
 }
 
 export type EventPayloadMap = {
@@ -79,49 +96,74 @@ function formatScheduled(scheduled: string | null): string | null {
   return date.toUTCString()
 }
 
-// Flatten a payload into the {{token}} values the renderer substitutes.
-// Date/URL derivation lives here; escaping + line-collapse is the
-// renderer's job. Token names must match TEMPLATE_TOKENS in the core.
-function buildTokens<K extends NotificationEventKey>(
+function nonEmpty(values: TokenValues): TokenValues {
+  const out: TokenValues = {}
+  for (const [k, v] of Object.entries(values)) {
+    if (v != null && v !== "") out[k] = v
+  }
+  return out
+}
+
+// Flatten a payload into the {{token}} values the renderer substitutes,
+// enriched with the full DB record when an entity id is present. The
+// scalar payload fields always win for the keys they carry (so the
+// freshly-built link and event-authoritative status never regress);
+// enrichment supplies the extra composable tokens.
+async function buildTokens<K extends NotificationEventKey>(
+  workspaceId: string,
   eventType: K,
   payload: EventPayloadMap[K],
-): TokenValues {
+): Promise<TokenValues> {
   switch (eventType) {
     case "stream.created": {
       const p = payload as StreamCreatedPayload
-      return {
+      const base: TokenValues = {
         title: p.title,
         scheduledStartTime: formatScheduled(p.scheduledStartTime),
         streamUrl: p.streamUrl,
       }
+      const enriched = p.streamId ? await enrichStream(p.streamId) : {}
+      return { ...enriched, ...nonEmpty(base) }
     }
     case "meeting.created": {
       const p = payload as MeetingCreatedPayload
-      return {
+      const base: TokenValues = {
         topic: p.topic,
         startTime: formatScheduled(p.startTime),
         joinUrl: p.joinUrl,
       }
+      const enriched = p.meetingId ? await enrichMeeting(p.meetingId) : {}
+      return { ...enriched, ...nonEmpty(base) }
     }
-    case "request.created": {
-      const p = payload as RequestCreatedPayload
-      return { title: p.title, status: p.status, requesterName: p.requesterName, linkUrl: p.linkUrl }
-    }
-    case "request.status_changed": {
-      const p = payload as RequestStatusChangedPayload
-      return { title: p.title, status: p.status, requesterName: p.requesterName, linkUrl: p.linkUrl }
-    }
+    case "request.created":
+    case "request.status_changed":
     case "request.archived": {
-      const p = payload as RequestArchivedPayload
-      return { title: p.title, requesterName: p.requesterName, linkUrl: p.linkUrl }
+      const p = payload as RequestCreatedPayload &
+        RequestStatusChangedPayload &
+        RequestArchivedPayload
+      const base: TokenValues = {
+        title: p.title,
+        status: p.status,
+        requesterName: p.requesterName,
+        linkUrl: p.linkUrl,
+      }
+      const enriched = p.requestId ? await enrichRequest(p.requestId) : {}
+      // linkUrl always from payload (built with the console base URL).
+      return { ...enriched, ...nonEmpty(base), linkUrl: p.linkUrl }
     }
-    case "booking.created": {
-      const p = payload as BookingCreatedPayload
-      return { title: p.title, status: p.status, requesterName: p.requesterName, linkUrl: p.linkUrl }
-    }
+    case "booking.created":
     case "booking.status_changed": {
-      const p = payload as BookingStatusChangedPayload
-      return { title: p.title, status: p.status, linkUrl: p.linkUrl }
+      const p = payload as BookingCreatedPayload & BookingStatusChangedPayload
+      const base: TokenValues = {
+        title: p.title,
+        status: p.status,
+        requesterName: p.requesterName,
+        linkUrl: p.linkUrl,
+      }
+      const enriched = p.trackingCode
+        ? await enrichBooking(p.trackingCode, workspaceId)
+        : {}
+      return { ...enriched, ...nonEmpty(base), linkUrl: p.linkUrl }
     }
     default:
       return {}
@@ -202,7 +244,7 @@ export async function dispatchEvent<K extends NotificationEventKey>(
   // One template lookup per dispatch (shared across all routes), then
   // fall back to the hardcoded default when no custom row is set.
   const template = await resolveTemplate(workspaceId, "group", eventType)
-  const text = renderTemplate(template, buildTokens(eventType, payload))
+  const text = renderTemplate(template, await buildTokens(workspaceId, eventType, payload))
   let succeeded = 0
 
   for (const route of routes) {

--- a/apps/console/server/notifications/enrich.ts
+++ b/apps/console/server/notifications/enrich.ts
@@ -1,0 +1,267 @@
+// Server-side token enrichment. Given an entity id, read the full row
+// from the shared Supabase DB (service-role admin client, bypasses RLS)
+// and project it onto the composable token names declared in
+// notification-templates-core's category catalogs.
+//
+// Every function is best-effort: any failure or missing row returns {}
+// so the caller falls back to the event payload — a DB hiccup must
+// never silence a notification.
+
+import { getSupabaseAdmin } from "../supabase-admin.js";
+import type { TokenValues } from "../../src/data/notification-templates-core.js";
+
+function fmtDate(v: string | null | undefined): string {
+  if (!v) return "";
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? "" : d.toUTCString();
+}
+
+function yesNo(v: boolean | null | undefined): string {
+  return v ? "Yes" : "No";
+}
+
+// cue start/duration are integer seconds — render as H:MM:SS / M:SS.
+function clock(seconds: number | null | undefined): string {
+  if (seconds == null || !Number.isFinite(seconds)) return "";
+  const s = Math.max(0, Math.floor(seconds));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  const pad = (n: number) => String(n).padStart(2, "0");
+  return h > 0 ? `${h}:${pad(m)}:${pad(sec)}` : `${m}:${pad(sec)}`;
+}
+
+export async function enrichRequest(requestId: string): Promise<TokenValues> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data } = await admin
+      .from("requests")
+      .select(
+        "title, status, priority, category, requested_by, due_date, created_at, updated_at, tracking_code, who, what, when_text, where_text, why, how, notes, flow",
+      )
+      .eq("id", requestId)
+      .maybeSingle();
+    if (!data) return {};
+    return {
+      title: data.title,
+      status: data.status,
+      priority: data.priority,
+      category: data.category,
+      requesterName: data.requested_by,
+      requestedBy: data.requested_by,
+      dueDate: fmtDate(data.due_date),
+      createdAt: fmtDate(data.created_at),
+      updatedAt: fmtDate(data.updated_at),
+      trackingCode: data.tracking_code,
+      who: data.who,
+      what: data.what,
+      whenText: data.when_text,
+      whereText: data.where_text,
+      why: data.why,
+      how: data.how,
+      notes: data.notes,
+      flow: data.flow,
+    };
+  } catch {
+    return {};
+  }
+}
+
+type BookingRow = {
+  booked_by: string;
+  status: string;
+  checked_out_at: string | null;
+  expected_return_at: string | null;
+  returned_at: string | null;
+  notes: string | null;
+  tracking_code: string;
+  equipment: { name: string; category: string; location: string; serial_number: string } | null;
+};
+
+// A tracking_code can cover a batch of bookings (non-unique by design),
+// so aggregate: first row drives the scalar fields, all rows feed the
+// equipment list + count.
+export async function enrichBooking(
+  trackingCode: string,
+  workspaceId: string,
+): Promise<TokenValues> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data } = await admin
+      .from("bookings")
+      .select(
+        "booked_by, status, checked_out_at, expected_return_at, returned_at, notes, tracking_code, equipment:equipment_id(name, category, location, serial_number)",
+      )
+      .eq("workspace_id", workspaceId)
+      .eq("tracking_code", trackingCode);
+    const rows = (data ?? []) as unknown as BookingRow[];
+    if (rows.length === 0) return {};
+    const first = rows[0];
+    const names = rows.map((r) => r.equipment?.name).filter(Boolean) as string[];
+    return {
+      status: first.status,
+      requesterName: first.booked_by,
+      bookedBy: first.booked_by,
+      checkedOutAt: fmtDate(first.checked_out_at),
+      expectedReturnAt: fmtDate(first.expected_return_at),
+      returnedAt: fmtDate(first.returned_at),
+      notes: first.notes,
+      trackingCode: first.tracking_code,
+      itemCount: String(rows.length),
+      equipmentName: first.equipment?.name ?? "",
+      equipmentNames: names.join(", "),
+      equipmentCategory: first.equipment?.category ?? "",
+      equipmentLocation: first.equipment?.location ?? "",
+      equipmentSerial: first.equipment?.serial_number ?? "",
+    };
+  } catch {
+    return {};
+  }
+}
+
+export async function enrichStream(streamId: string): Promise<TokenValues> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data } = await admin
+      .from("streams")
+      .select(
+        "title, description, scheduled_start_time, actual_start_time, stream_status, privacy_status, is_for_kids, latency_preference, tags, created_at, stream_url",
+      )
+      .eq("id", streamId)
+      .maybeSingle();
+    if (!data) return {};
+    return {
+      title: data.title,
+      description: data.description,
+      scheduledStartTime: fmtDate(data.scheduled_start_time),
+      actualStartTime: fmtDate(data.actual_start_time),
+      status: data.stream_status,
+      privacyStatus: data.privacy_status,
+      isForKids: yesNo(data.is_for_kids),
+      latencyPreference: data.latency_preference,
+      tags: Array.isArray(data.tags) ? data.tags.join(", ") : "",
+      createdAt: fmtDate(data.created_at),
+      streamUrl: data.stream_url,
+    };
+  } catch {
+    return {};
+  }
+}
+
+export async function enrichMeeting(meetingId: string): Promise<TokenValues> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data } = await admin
+      .from("zoom_meetings")
+      .select(
+        "topic, description, start_time, duration, timezone, meeting_type, waiting_room, recurrence_type, created_at, join_url",
+      )
+      .eq("id", meetingId)
+      .maybeSingle();
+    if (!data) return {};
+    return {
+      topic: data.topic,
+      description: data.description,
+      startTime: fmtDate(data.start_time),
+      duration: data.duration != null ? `${data.duration} min` : "",
+      timezone: data.timezone,
+      meetingType: data.meeting_type,
+      waitingRoom: yesNo(data.waiting_room),
+      recurrenceType: data.recurrence_type,
+      createdAt: fmtDate(data.created_at),
+      joinUrl: data.join_url,
+    };
+  } catch {
+    return {};
+  }
+}
+
+// Cue assignment enrichment. Returns the cue/track/event token values
+// plus `eventId` so the caller can build the link URL. `title` is the
+// cue label (the assignment's subject).
+export async function enrichCue(
+  cueId: string,
+): Promise<(TokenValues & { eventId?: string }) | null> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data: cue } = await admin
+      .from("cues")
+      .select("label, start, duration, type, notes, track_id")
+      .eq("id", cueId)
+      .maybeSingle();
+    if (!cue) return null;
+
+    const { data: track } = await admin
+      .from("tracks")
+      .select("name, event_id")
+      .eq("id", cue.track_id)
+      .maybeSingle();
+    if (!track) return null;
+
+    const { data: event } = await admin
+      .from("events")
+      .select("id, title, description, scheduled_at, duration")
+      .eq("id", track.event_id)
+      .maybeSingle();
+    if (!event) return null;
+
+    return {
+      eventId: event.id,
+      title: cue.label,
+      eventName: event.title,
+      eventDescription: event.description,
+      eventScheduledAt: fmtDate(event.scheduled_at),
+      eventDuration: event.duration != null ? `${event.duration} min` : "",
+      trackName: track.name,
+      cueStart: clock(cue.start),
+      cueDuration: clock(cue.duration),
+      cueType: cue.type,
+      cueNotes: cue.notes,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export async function enrichChecklistItem(
+  itemId: string,
+): Promise<(TokenValues & { checklistId?: string }) | null> {
+  try {
+    const admin = getSupabaseAdmin();
+    const { data: item } = await admin
+      .from("checklist_items")
+      .select("label, checked, checklist_id, section_id")
+      .eq("id", itemId)
+      .maybeSingle();
+    if (!item) return null;
+
+    const { data: checklist } = await admin
+      .from("checklists")
+      .select("id, name, description, scheduled_at")
+      .eq("id", item.checklist_id)
+      .maybeSingle();
+    if (!checklist) return null;
+
+    let sectionName = "";
+    if (item.section_id) {
+      const { data: section } = await admin
+        .from("checklist_sections")
+        .select("name")
+        .eq("id", item.section_id)
+        .maybeSingle();
+      sectionName = section?.name ?? "";
+    }
+
+    return {
+      checklistId: checklist.id,
+      title: item.label,
+      checklistName: checklist.name,
+      checklistDescription: checklist.description,
+      checklistScheduledAt: fmtDate(checklist.scheduled_at),
+      sectionName,
+      itemChecked: yesNo(item.checked),
+    };
+  } catch {
+    return null;
+  }
+}

--- a/apps/console/server/notifications/templates.ts
+++ b/apps/console/server/notifications/templates.ts
@@ -1,0 +1,32 @@
+import { getSupabaseAdmin } from "../supabase-admin.js";
+import {
+  DEFAULT_TEMPLATES,
+  type MessageType,
+  type TemplateScope,
+} from "../../src/data/notification-templates-core.js";
+
+// Returns the workspace's custom template body for this message type,
+// or the hardcoded default when none is set. Any lookup failure falls
+// back to the default so a DB hiccup never silences notifications.
+export async function resolveTemplate(
+  workspaceId: string,
+  scope: TemplateScope,
+  messageType: MessageType,
+): Promise<string> {
+  const fallback = DEFAULT_TEMPLATES[messageType];
+  try {
+    const admin = getSupabaseAdmin();
+    const { data, error } = await admin
+      .from("notification_message_templates")
+      .select("body")
+      .eq("workspace_id", workspaceId)
+      .eq("scope", scope)
+      .eq("message_type", messageType)
+      .maybeSingle();
+
+    if (error || !data?.body) return fallback;
+    return data.body as string;
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/console/server/youtube-oauth.ts
+++ b/apps/console/server/youtube-oauth.ts
@@ -7,6 +7,19 @@ export type YouTubeOAuthConfig = {
   clientSecret: string
 }
 
+/**
+ * Thrown when Google rejects a refresh token with `invalid_grant` — the
+ * refresh token is permanently dead (expired in testing mode, revoked, or
+ * the account password changed). Distinct from transient failures so the
+ * caller can prompt a reconnect instead of retrying.
+ */
+export class YouTubeReauthRequiredError extends Error {
+  constructor(message = "YouTube refresh token is no longer valid; reconnect required") {
+    super(message)
+    this.name = "YouTubeReauthRequiredError"
+  }
+}
+
 type TokenResponse = {
   access_token: string
   refresh_token?: string
@@ -100,6 +113,14 @@ export async function refreshYouTubeToken(
   })
 
   if (!response.ok) {
+    const contentType = response.headers.get("content-type") ?? ""
+    if (contentType.includes("application/json")) {
+      const data = await response.json() as { error?: string; error_description?: string }
+      if (data.error === "invalid_grant") {
+        throw new YouTubeReauthRequiredError(data.error_description ?? undefined)
+      }
+      throw new Error(data.error_description ?? data.error ?? "YouTube token refresh failed")
+    }
     throw new Error(await getErrorMessage(response, "YouTube token refresh failed"))
   }
 

--- a/apps/console/src/App.tsx
+++ b/apps/console/src/App.tsx
@@ -47,6 +47,7 @@ const TermsOfUseScreen = lazy(() => import('./screens/public/terms').then((m) =>
 const SupportScreen = lazy(() => import('./screens/public/support').then((m) => ({ default: m.SupportScreen })))
 const ZoomDocsScreen = lazy(() => import('./screens/public/zoom-docs').then((m) => ({ default: m.ZoomDocsScreen })))
 const SettingsScreen = lazy(() => import('./screens/account/settings/page').then((m) => ({ default: m.SettingsScreen })))
+const MessageTemplateDetailScreen = lazy(() => import('./screens/account/settings/message-templates/detail/page').then((m) => ({ default: m.MessageTemplateDetailScreen })))
 const CueSheetShareScreen = lazy(() => import('./screens/public/cue-sheet-share/page').then((m) => ({ default: m.CueSheetShareScreen })))
 
 function FullScreenSpinner() {
@@ -131,6 +132,7 @@ const router = createBrowserRouter([
             { index: true, element: <Navigate to={`/${routes.dashboard}`} replace /> },
             { path: routes.dashboard, element: <RequestsProvider><EquipmentProvider><BroadcastProvider><CueSheetProvider><DashboardScreen /></CueSheetProvider></BroadcastProvider></EquipmentProvider></RequestsProvider> },
             { path: routes.settings, element: <SettingsScreen /> },
+            { path: routes.messageTemplateDetail, element: <MessageTemplateDetailScreen /> },
             {
                 element: <RequestsProvider><Outlet /></RequestsProvider>,
                 children: [

--- a/apps/console/src/data/fetch-broadcast.ts
+++ b/apps/console/src/data/fetch-broadcast.ts
@@ -7,7 +7,7 @@ import { supabase } from "@moc/data/supabase";
 import { getCurrentWorkspaceId } from "./current-workspace";
 
 const MEDIA_COLUMNS =
-  "id, name, type, url, thumbnail_url, duration_seconds, width, height, created_at";
+  "id, name, type, url, thumbnail_url, duration_seconds, width, height, blob_fetchable, created_at";
 
 type MediaRow = {
   id: string;
@@ -18,6 +18,7 @@ type MediaRow = {
   duration_seconds: number | null;
   width: number | null;
   height: number | null;
+  blob_fetchable: boolean | null;
   created_at: string;
 };
 
@@ -68,6 +69,7 @@ function mapMediaRow(row: MediaRow): MediaItem {
     duration: row.duration_seconds,
     width: row.width,
     height: row.height,
+    blobFetchable: row.blob_fetchable,
     createdAt: row.created_at,
   };
 }

--- a/apps/console/src/data/fetch-streams.ts
+++ b/apps/console/src/data/fetch-streams.ts
@@ -1,4 +1,4 @@
-import type { Stream, StreamPreset, YouTubeConnection, YouTubeCategory, YouTubePlaylist } from "@moc/types/broadcast/stream"
+import type { Stream, StreamPreset, YouTubeConnection, YouTubeConnectionStatus, YouTubeCategory, YouTubePlaylist } from "@moc/types/broadcast/stream"
 import { supabase } from "@moc/data/supabase"
 import { getCurrentWorkspaceId } from "./current-workspace"
 import { fetchVideoCategories, fetchChannelPlaylists } from "@/lib/youtube-client"
@@ -42,6 +42,7 @@ type ConnectionRow = {
   connected_by: string
   created_at: string
   token_expires_at: string
+  status: YouTubeConnectionStatus
 }
 
 function mapStreamRow(row: StreamRow): Stream {
@@ -86,6 +87,7 @@ function mapConnectionRow(row: ConnectionRow): YouTubeConnection {
     connectedBy: row.connected_by,
     createdAt: row.created_at,
     tokenExpiresAt: row.token_expires_at,
+    status: row.status,
   }
 }
 
@@ -128,7 +130,7 @@ export async function fetchYouTubeConnection(): Promise<YouTubeConnection | null
   const workspaceId = await getCurrentWorkspaceId()
   const { data, error } = await supabase
     .from("youtube_connections")
-    .select("id, workspace_id, channel_id, channel_title, presets, connected_by, created_at, token_expires_at")
+    .select("id, workspace_id, channel_id, channel_title, presets, connected_by, created_at, token_expires_at, status")
     .eq("workspace_id", workspaceId)
     .maybeSingle()
 

--- a/apps/console/src/data/mutate-broadcast.ts
+++ b/apps/console/src/data/mutate-broadcast.ts
@@ -9,7 +9,7 @@ import { randomId } from "@moc/utils/random-id";
 import { probeMediaMetadata } from "@moc/utils/media-source";
 
 const MEDIA_COLUMNS =
-  "id, name, type, url, thumbnail_url, duration_seconds, width, height, created_at";
+  "id, name, type, url, thumbnail_url, duration_seconds, width, height, blob_fetchable, created_at";
 
 type MediaRow = {
   id: string;
@@ -20,6 +20,7 @@ type MediaRow = {
   duration_seconds: number | null;
   width: number | null;
   height: number | null;
+  blob_fetchable: boolean | null;
   created_at: string;
 };
 
@@ -33,6 +34,7 @@ function mapMediaRow(row: MediaRow): MediaItem {
     duration: row.duration_seconds,
     width: row.width,
     height: row.height,
+    blobFetchable: row.blob_fetchable,
     createdAt: row.created_at,
   };
 }
@@ -207,6 +209,31 @@ export async function uploadPlaylistThumbnail(file: File): Promise<string> {
   return data.publicUrl;
 }
 
+// Mirrors a resolved stream-thumbnail blob into the same public `media`
+// bucket, namespaced under <workspace_id>/stream-thumbnails/. Used so the
+// workspace stream preset references a durable, CORS-safe Supabase URL for
+// Upload-mode thumbnails instead of a YouTube CDN URL we can't re-fetch.
+export async function uploadStreamThumbnail(blob: Blob): Promise<string> {
+  const workspaceId = await getCurrentWorkspaceId();
+  const ext = blob.type === "image/png" ? "png" : "jpg";
+  const path = `${workspaceId}/stream-thumbnails/${randomId()}.${ext}`;
+
+  const { error: uploadError } = await supabase.storage
+    .from("media")
+    .upload(path, blob, {
+      cacheControl: "3600",
+      upsert: false,
+      contentType: blob.type || "image/jpeg",
+    });
+
+  if (uploadError) {
+    throw new Error(uploadError.message);
+  }
+
+  const { data } = supabase.storage.from("media").getPublicUrl(path);
+  return data.publicUrl;
+}
+
 export async function createMediaItem(item: MediaItem): Promise<MediaItem> {
   const workspaceId = await getCurrentWorkspaceId();
   const payload = {
@@ -219,6 +246,7 @@ export async function createMediaItem(item: MediaItem): Promise<MediaItem> {
     duration_seconds: item.duration,
     width: item.width,
     height: item.height,
+    blob_fetchable: item.blobFetchable,
   };
 
   const { data, error } = await supabase

--- a/apps/console/src/data/mutate-streams.ts
+++ b/apps/console/src/data/mutate-streams.ts
@@ -123,36 +123,6 @@ async function insertLocalStream(payload: LocalStreamInsertPayload): Promise<voi
   }
 }
 
-async function restoreLocalStream(stream: Stream): Promise<void> {
-  await insertLocalStream({
-    id: stream.id,
-    workspace_id: stream.workspaceId,
-    youtube_broadcast_id: stream.youtubeBroadcastId,
-    youtube_stream_id: stream.youtubeStreamId,
-    title: stream.title,
-    description: stream.description,
-    thumbnail_url: stream.thumbnailUrl,
-    privacy_status: stream.privacyStatus,
-    is_for_kids: stream.isForKids,
-    scheduled_start_time: stream.scheduledStartTime,
-    actual_start_time: stream.actualStartTime,
-    actual_end_time: stream.actualEndTime,
-    stream_status: stream.streamStatus,
-    stream_url: stream.streamUrl,
-    stream_key: stream.streamKey,
-    ingestion_url: stream.ingestionUrl,
-    category_id: stream.categoryId,
-    tags: stream.tags,
-    latency_preference: stream.latencyPreference,
-    enable_dvr: stream.enableDvr,
-    enable_embed: stream.enableEmbed,
-    enable_auto_start: stream.enableAutoStart,
-    enable_auto_stop: stream.enableAutoStop,
-    playlist_id: stream.playlistId,
-    created_by: stream.createdBy,
-  })
-}
-
 export async function createStream(params: CreateStreamParams): Promise<StreamMutationResult> {
   const workspaceId = await getCurrentWorkspaceId()
   const { data: { user } } = await supabase.auth.getUser()
@@ -430,6 +400,20 @@ export async function updateStream(
 }
 
 export async function deleteStream(stream: Stream): Promise<void> {
+  // Delete the YouTube broadcast first. Only if it's gone on YouTube's
+  // side do we delete our row — so a failed external delete never leaves
+  // an orphaned broadcast we can no longer reach from the app. A 404
+  // means it was already removed on YouTube, which is success here.
+  const response = await youtubeApiFetch(
+    `/liveBroadcasts?id=${stream.youtubeBroadcastId}`,
+    { method: "DELETE" },
+  )
+
+  if (!response.ok && response.status !== 404) {
+    const err = await response.text()
+    throw new Error(`Failed to delete broadcast on YouTube; the stream was kept: ${err}`)
+  }
+
   const { error } = await supabase
     .from("streams")
     .delete()
@@ -437,23 +421,6 @@ export async function deleteStream(stream: Stream): Promise<void> {
 
   if (error) {
     throw new Error(error.message)
-  }
-
-  const response = await youtubeApiFetch(
-    `/liveBroadcasts?id=${stream.youtubeBroadcastId}`,
-    { method: "DELETE" },
-  )
-
-  if (!response.ok) {
-    try {
-      await restoreLocalStream(stream)
-    } catch (restoreError) {
-      const err = await response.text()
-      throw new Error(`Failed to delete broadcast and could not restore the local stream: ${err}; ${(restoreError as Error).message}`)
-    }
-
-    const err = await response.text()
-    throw new Error(`Failed to delete broadcast: ${err}`)
   }
 }
 

--- a/apps/console/src/data/mutate-streams.ts
+++ b/apps/console/src/data/mutate-streams.ts
@@ -5,7 +5,6 @@ import {
   youtubeApiFetch,
   revokeToken,
   uploadThumbnail,
-  uploadThumbnailFromUrl,
   updateVideoMetadata,
   addVideoToPlaylist,
 } from "@/lib/youtube-client"
@@ -13,10 +12,34 @@ import { fetchStreamById } from "./fetch-streams"
 import { randomId } from "@moc/utils/random-id"
 import { notifyStreamCreated } from "./notify-event"
 
+// A thumbnail that has ALREADY been resolved to bytes in the modal. The data
+// layer never fetches a thumbnail URL itself (that fetch is CORS-gated and was
+// the source of the silent-failure bug) — it only POSTs these bytes to
+// YouTube. `origin`/`sourceUrl` carry what the workspace preset should persist:
+// Upload mode mirrors `blob` to Supabase (sourceUrl null); URL/Media modes
+// persist the already-validated `sourceUrl`.
 export type ThumbnailSource =
-  | { type: "file"; file: File }
-  | { type: "url"; url: string }
+  | { blob: Blob; origin: "file" | "url" | "media"; sourceUrl: string | null }
   | null
+
+// createStream/updateStream are non-fatal w.r.t. the thumbnail: the stream is
+// always created/updated. If YouTube itself rejects the thumbnail POST after
+// the broadcast exists (almost always: channel not verified for custom
+// thumbnails), `thumbnailError` carries a plain-language reason for the caller
+// to surface — we do NOT roll back the broadcast (decision B2).
+export type StreamMutationResult = {
+  stream: Stream
+  thumbnailError: string | null
+}
+
+// Maps a YouTube thumbnail-POST failure to non-technical, actionable copy.
+function describeThumbnailFailure(error: unknown): string {
+  const raw = error instanceof Error ? error.message : String(error)
+  if (/unauthoriz|forbidden|403|not.*verif|ineligible/i.test(raw)) {
+    return "YouTube rejected the thumbnail — your channel may not be verified for custom thumbnails. The stream was created without it."
+  }
+  return "YouTube rejected the thumbnail, so the stream was created without it."
+}
 
 type CreateStreamParams = {
   title: string
@@ -130,7 +153,7 @@ async function restoreLocalStream(stream: Stream): Promise<void> {
   })
 }
 
-export async function createStream(params: CreateStreamParams): Promise<Stream> {
+export async function createStream(params: CreateStreamParams): Promise<StreamMutationResult> {
   const workspaceId = await getCurrentWorkspaceId()
   const { data: { user } } = await supabase.auth.getUser()
 
@@ -207,24 +230,25 @@ export async function createStream(params: CreateStreamParams): Promise<Stream> 
     throw new Error(`Failed to bind stream: ${err}`)
   }
 
-  // 4. Set thumbnail (if provided)
+  // 4. Set thumbnail (if provided). The bytes were already resolved and
+  //    validated in the modal — we never fetch a thumbnail URL here, so the
+  //    only failure left is YouTube itself rejecting the POST (Failure B).
   let thumbnailUrl: string | null = broadcast.snippet?.thumbnails?.default?.url ?? null
+  let thumbnailError: string | null = null
   if (params.thumbnail) {
     try {
-      if (params.thumbnail.type === "file") {
-        await uploadThumbnail(broadcast.id, params.thumbnail.file)
-      } else {
-        await uploadThumbnailFromUrl(broadcast.id, params.thumbnail.url)
-      }
+      await uploadThumbnail(broadcast.id, params.thumbnail.blob)
       // Re-fetch to get the new thumbnail URL from YouTube
       const refreshed = await youtubeApiFetch(`/liveBroadcasts?part=snippet&id=${broadcast.id}`)
       if (refreshed.ok) {
         const refreshedData = await refreshed.json()
         thumbnailUrl = refreshedData.items?.[0]?.snippet?.thumbnails?.medium?.url ?? thumbnailUrl
       }
-    } catch {
-      // Thumbnail upload is non-critical — continue with stream creation
-      console.warn("Thumbnail upload failed, continuing without custom thumbnail")
+    } catch (error) {
+      // Decision B2: the broadcast already exists and is usable — keep the
+      // stream, surface a precise reason instead of rolling back or silently
+      // swallowing (the original bug).
+      thumbnailError = describeThumbnailFailure(error)
     }
   }
 
@@ -300,13 +324,13 @@ export async function createStream(params: CreateStreamParams): Promise<Stream> 
 
   notifyStreamCreated(saved.id)
 
-  return saved
+  return { stream: saved, thumbnailError }
 }
 
 export async function updateStream(
   stream: Stream,
   thumbnail?: ThumbnailSource,
-): Promise<Stream> {
+): Promise<StreamMutationResult> {
   // Update broadcast on YouTube (snippet, status, and contentDetails)
   const response = await youtubeApiFetch(
     "/liveBroadcasts?part=snippet,status,contentDetails",
@@ -339,15 +363,13 @@ export async function updateStream(
     throw new Error(`Failed to update broadcast: ${err}`)
   }
 
-  // Update thumbnail if a new one was provided
+  // Update thumbnail if a new one was provided. Bytes were already resolved
+  // and validated in the modal — no fetch here.
   let thumbnailUrl = stream.thumbnailUrl
+  let thumbnailError: string | null = null
   if (thumbnail) {
     try {
-      if (thumbnail.type === "file") {
-        await uploadThumbnail(stream.youtubeBroadcastId, thumbnail.file)
-      } else {
-        await uploadThumbnailFromUrl(stream.youtubeBroadcastId, thumbnail.url)
-      }
+      await uploadThumbnail(stream.youtubeBroadcastId, thumbnail.blob)
       const refreshed = await youtubeApiFetch(
         `/liveBroadcasts?part=snippet&id=${stream.youtubeBroadcastId}`,
       )
@@ -356,8 +378,8 @@ export async function updateStream(
         thumbnailUrl =
           refreshedData.items?.[0]?.snippet?.thumbnails?.medium?.url ?? thumbnailUrl
       }
-    } catch {
-      console.warn("Thumbnail update failed")
+    } catch (error) {
+      thumbnailError = describeThumbnailFailure(error)
     }
   }
 
@@ -404,7 +426,7 @@ export async function updateStream(
     throw new Error("Updated stream could not be reloaded")
   }
 
-  return saved
+  return { stream: saved, thumbnailError }
 }
 
 export async function deleteStream(stream: Stream): Promise<void> {

--- a/apps/console/src/data/notification-templates-core.test.ts
+++ b/apps/console/src/data/notification-templates-core.test.ts
@@ -1,11 +1,12 @@
-// Behaviour tests for the template engine and the friendly built-in
-// defaults. The defaults are intentionally NOT the old hardcoded
-// wording, so these tests pin the new rendering and — more importantly
-// — the structural guarantees the renderer must keep:
-//   * token-free lines always render
-//   * a line whose tokens ALL resolve empty is dropped
-//   * blank runs collapse, leading/trailing blanks are trimmed
+// Behaviour + integrity tests for the template engine and the
+// composable token catalog. Exact default wording is intentionally NOT
+// pinned (admins/devs iterate on it); instead we lock the structural
+// guarantees that must always hold:
+//   * every token a default template references is valid for its type
+//   * token-free lines always render; all-empty-token lines drop
+//   * blank runs collapse, leading/trailing blanks trimmed
 //   * text tokens are HTML-escaped, URL tokens are not
+//   * the category catalogs stay internally consistent
 //
 // Run: bun test apps/console/src/data/notification-templates-core.test.ts
 
@@ -21,7 +22,26 @@ import {
 
 const ALL_TYPES = Object.keys(DEFAULT_TEMPLATES) as MessageType[];
 
-// ---- structural invariants across every default template ----
+// ---- catalog integrity ----
+
+for (const type of ALL_TYPES) {
+  test(`catalog has no duplicate token names: ${type}`, () => {
+    const names = TEMPLATE_TOKENS[type].map((t) => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+
+  test(`default template only references valid tokens: ${type}`, () => {
+    expect(validateTemplate(type, DEFAULT_TEMPLATES[type])).toEqual([]);
+  });
+
+  test(`every catalog token has a sample value: ${type}`, () => {
+    for (const t of TEMPLATE_TOKENS[type]) {
+      expect(SAMPLE_TOKENS[type]).toHaveProperty(t.name);
+    }
+  });
+}
+
+// ---- default rendering invariants ----
 
 for (const type of ALL_TYPES) {
   test(`default renders cleanly with full sample data: ${type}`, () => {
@@ -31,14 +51,12 @@ for (const type of ALL_TYPES) {
     expect(out).not.toMatch(/\n$/); // no trailing blank
     expect(out).not.toContain("\n\n\n"); // no double blank line
     expect(out).not.toMatch(/\{\{|\}\}/); // every placeholder substituted
-    // Required fields surface; the link token is raw (unescaped).
-    const url = String(SAMPLE_TOKENS[type].linkUrl ?? SAMPLE_TOKENS[type].streamUrl ?? SAMPLE_TOKENS[type].joinUrl);
-    expect(out).toContain(url);
+    const s = SAMPLE_TOKENS[type];
+    const url = String(s.linkUrl ?? s.streamUrl ?? s.joinUrl);
+    expect(out).toContain(url); // the action link survives
   });
 
-  test(`every optional-only line drops when its token is empty: ${type}`, () => {
-    // Blank out every token, keep only required ones non-empty so the
-    // message still renders. Required = title/topic + the url token.
+  test(`optional-only lines drop when their token is empty: ${type}`, () => {
     const tokens: Record<string, string> = {};
     for (const t of TEMPLATE_TOKENS[type]) tokens[t.name] = "";
     if ("title" in tokens) tokens.title = "T";
@@ -50,91 +68,22 @@ for (const type of ALL_TYPES) {
     expect(out).not.toContain("From "); // requesterName line gone
     expect(out).not.toContain("Status:"); // status line gone
     expect(out).not.toContain("Duty:"); // duty line gone
-    expect(out).not.toContain("Hey "); // assigneeName greeting gone
+    expect(out).not.toContain("Hey "); // assignee greeting gone
     expect(out).not.toMatch(/^\n|\n$|\n\n\n/);
   });
 }
 
-// ---- explicit format lock (representative types) ----
-
-test("request.created — all fields", () => {
-  expect(renderTemplate(DEFAULT_TEMPLATES["request.created"], SAMPLE_TOKENS["request.created"])).toBe(
-    [
-      "✨ <b>New request just came in</b>",
-      "",
-      "Lower-third graphic for guest speaker",
-      "🙋 From Tendai M.",
-      "📌 Status: <i>not started</i>",
-      "",
-      '👉 <a href="https://app.example.com/requests/123">Open the request</a>',
-    ].join("\n"),
-  );
-});
-
-test("request.created — no requester, no status: optional lines collapse", () => {
-  expect(
-    renderTemplate(DEFAULT_TEMPLATES["request.created"], {
-      title: "Lower-third graphic for guest speaker",
-      status: null,
-      requesterName: null,
-      linkUrl: "https://app.example.com/requests/123",
-    }),
-  ).toBe(
-    [
-      "✨ <b>New request just came in</b>",
-      "",
-      "Lower-third graphic for guest speaker",
-      "",
-      '👉 <a href="https://app.example.com/requests/123">Open the request</a>',
-    ].join("\n"),
-  );
-});
-
-test("assignment.cue — all fields incl. greeting", () => {
-  expect(renderTemplate(DEFAULT_TEMPLATES["assignment.cue"], SAMPLE_TOKENS["assignment.cue"])).toBe(
-    [
-      "👋 Hey Craig C.!",
-      "🎬 <b>You've been assigned to a cue</b>",
-      "",
-      "Roll opening VT",
-      "📋 Event: Sunday Service",
-      "🛠 Duty: <i>Playback</i>",
-      "",
-      '👉 <a href="https://app.example.com/cue-sheet/events/77">Open the event</a>',
-    ].join("\n"),
-  );
-});
-
-test("assignment.cue — no assignee name, no duty: greeting + duty lines drop", () => {
-  expect(
-    renderTemplate(DEFAULT_TEMPLATES["assignment.cue"], {
-      title: "Roll opening VT",
-      eventName: "Sunday Service",
-      duty: "",
-      assigneeName: "",
-      linkUrl: "https://app.example.com/cue-sheet/events/77",
-    }),
-  ).toBe(
-    [
-      "🎬 <b>You've been assigned to a cue</b>",
-      "",
-      "Roll opening VT",
-      "📋 Event: Sunday Service",
-      "",
-      '👉 <a href="https://app.example.com/cue-sheet/events/77">Open the event</a>',
-    ].join("\n"),
-  );
-});
-
 // ---- behaviour ----
 
 test("text tokens are HTML-escaped, URL tokens are not", () => {
-  const out = renderTemplate(DEFAULT_TEMPLATES["request.created"], {
-    title: "A & B <c>",
-    status: "x>y",
-    requesterName: "M&Co",
-    linkUrl: "https://x?a=1&b=2",
-  });
+  const out = renderTemplate(
+    "{{title}}\n{{requesterName}}\n<a href=\"{{linkUrl}}\">x</a>",
+    {
+      title: "A & B <c>",
+      requesterName: "M&Co",
+      linkUrl: "https://x?a=1&b=2",
+    },
+  );
   expect(out).toContain("A &amp; B &lt;c&gt;");
   expect(out).toContain("M&amp;Co");
   expect(out).toContain('href="https://x?a=1&b=2"'); // URL untouched
@@ -151,8 +100,20 @@ test("token-free lines are always kept; blank runs collapse", () => {
 });
 
 test("validateTemplate flags unknown tokens for the type", () => {
-  expect(validateTemplate("request.created", "{{title}} {{linkUrl}}")).toEqual([]);
+  expect(validateTemplate("request.created", "{{title}} {{linkUrl}} {{priority}} {{dueDate}}")).toEqual([]);
   expect(
     validateTemplate("request.created", "{{title}} {{bogus}} {{joinUrl}}").sort(),
   ).toEqual(["bogus", "joinUrl"]);
+});
+
+test("request category exposes the rich composable fields", () => {
+  const names = new Set(TEMPLATE_TOKENS["request.created"].map((t) => t.name));
+  for (const f of ["priority", "category", "dueDate", "requestedBy", "trackingCode", "who", "what"]) {
+    expect(names.has(f)).toBe(true);
+  }
+  // request assignment shares the request category + DM-only fields
+  const asg = new Set(TEMPLATE_TOKENS["assignment.request"].map((t) => t.name));
+  expect(asg.has("priority")).toBe(true);
+  expect(asg.has("duty")).toBe(true);
+  expect(asg.has("assigneeName")).toBe(true);
 });

--- a/apps/console/src/data/notification-templates-core.test.ts
+++ b/apps/console/src/data/notification-templates-core.test.ts
@@ -1,0 +1,158 @@
+// Behaviour tests for the template engine and the friendly built-in
+// defaults. The defaults are intentionally NOT the old hardcoded
+// wording, so these tests pin the new rendering and — more importantly
+// — the structural guarantees the renderer must keep:
+//   * token-free lines always render
+//   * a line whose tokens ALL resolve empty is dropped
+//   * blank runs collapse, leading/trailing blanks are trimmed
+//   * text tokens are HTML-escaped, URL tokens are not
+//
+// Run: bun test apps/console/src/data/notification-templates-core.test.ts
+
+import { test, expect } from "bun:test";
+import {
+  DEFAULT_TEMPLATES,
+  SAMPLE_TOKENS,
+  TEMPLATE_TOKENS,
+  renderTemplate,
+  validateTemplate,
+  type MessageType,
+} from "./notification-templates-core";
+
+const ALL_TYPES = Object.keys(DEFAULT_TEMPLATES) as MessageType[];
+
+// ---- structural invariants across every default template ----
+
+for (const type of ALL_TYPES) {
+  test(`default renders cleanly with full sample data: ${type}`, () => {
+    const out = renderTemplate(DEFAULT_TEMPLATES[type], SAMPLE_TOKENS[type]);
+    expect(out.length).toBeGreaterThan(0);
+    expect(out).not.toMatch(/^\n/); // no leading blank
+    expect(out).not.toMatch(/\n$/); // no trailing blank
+    expect(out).not.toContain("\n\n\n"); // no double blank line
+    expect(out).not.toMatch(/\{\{|\}\}/); // every placeholder substituted
+    // Required fields surface; the link token is raw (unescaped).
+    const url = String(SAMPLE_TOKENS[type].linkUrl ?? SAMPLE_TOKENS[type].streamUrl ?? SAMPLE_TOKENS[type].joinUrl);
+    expect(out).toContain(url);
+  });
+
+  test(`every optional-only line drops when its token is empty: ${type}`, () => {
+    // Blank out every token, keep only required ones non-empty so the
+    // message still renders. Required = title/topic + the url token.
+    const tokens: Record<string, string> = {};
+    for (const t of TEMPLATE_TOKENS[type]) tokens[t.name] = "";
+    if ("title" in tokens) tokens.title = "T";
+    if ("topic" in tokens) tokens.topic = "Topic";
+    tokens.linkUrl = "https://x/1";
+    tokens.streamUrl = "https://x/1";
+    tokens.joinUrl = "https://x/1";
+    const out = renderTemplate(DEFAULT_TEMPLATES[type], tokens);
+    expect(out).not.toContain("From "); // requesterName line gone
+    expect(out).not.toContain("Status:"); // status line gone
+    expect(out).not.toContain("Duty:"); // duty line gone
+    expect(out).not.toContain("Hey "); // assigneeName greeting gone
+    expect(out).not.toMatch(/^\n|\n$|\n\n\n/);
+  });
+}
+
+// ---- explicit format lock (representative types) ----
+
+test("request.created — all fields", () => {
+  expect(renderTemplate(DEFAULT_TEMPLATES["request.created"], SAMPLE_TOKENS["request.created"])).toBe(
+    [
+      "✨ <b>New request just came in</b>",
+      "",
+      "Lower-third graphic for guest speaker",
+      "🙋 From Tendai M.",
+      "📌 Status: <i>not started</i>",
+      "",
+      '👉 <a href="https://app.example.com/requests/123">Open the request</a>',
+    ].join("\n"),
+  );
+});
+
+test("request.created — no requester, no status: optional lines collapse", () => {
+  expect(
+    renderTemplate(DEFAULT_TEMPLATES["request.created"], {
+      title: "Lower-third graphic for guest speaker",
+      status: null,
+      requesterName: null,
+      linkUrl: "https://app.example.com/requests/123",
+    }),
+  ).toBe(
+    [
+      "✨ <b>New request just came in</b>",
+      "",
+      "Lower-third graphic for guest speaker",
+      "",
+      '👉 <a href="https://app.example.com/requests/123">Open the request</a>',
+    ].join("\n"),
+  );
+});
+
+test("assignment.cue — all fields incl. greeting", () => {
+  expect(renderTemplate(DEFAULT_TEMPLATES["assignment.cue"], SAMPLE_TOKENS["assignment.cue"])).toBe(
+    [
+      "👋 Hey Craig C.!",
+      "🎬 <b>You've been assigned to a cue</b>",
+      "",
+      "Roll opening VT",
+      "📋 Event: Sunday Service",
+      "🛠 Duty: <i>Playback</i>",
+      "",
+      '👉 <a href="https://app.example.com/cue-sheet/events/77">Open the event</a>',
+    ].join("\n"),
+  );
+});
+
+test("assignment.cue — no assignee name, no duty: greeting + duty lines drop", () => {
+  expect(
+    renderTemplate(DEFAULT_TEMPLATES["assignment.cue"], {
+      title: "Roll opening VT",
+      eventName: "Sunday Service",
+      duty: "",
+      assigneeName: "",
+      linkUrl: "https://app.example.com/cue-sheet/events/77",
+    }),
+  ).toBe(
+    [
+      "🎬 <b>You've been assigned to a cue</b>",
+      "",
+      "Roll opening VT",
+      "📋 Event: Sunday Service",
+      "",
+      '👉 <a href="https://app.example.com/cue-sheet/events/77">Open the event</a>',
+    ].join("\n"),
+  );
+});
+
+// ---- behaviour ----
+
+test("text tokens are HTML-escaped, URL tokens are not", () => {
+  const out = renderTemplate(DEFAULT_TEMPLATES["request.created"], {
+    title: "A & B <c>",
+    status: "x>y",
+    requesterName: "M&Co",
+    linkUrl: "https://x?a=1&b=2",
+  });
+  expect(out).toContain("A &amp; B &lt;c&gt;");
+  expect(out).toContain("M&amp;Co");
+  expect(out).toContain('href="https://x?a=1&b=2"'); // URL untouched
+});
+
+test("a line whose tokens all resolve empty is dropped", () => {
+  expect(renderTemplate("Header\nFrom: {{requesterName}}\nEnd", { requesterName: "" })).toBe(
+    "Header\nEnd",
+  );
+});
+
+test("token-free lines are always kept; blank runs collapse", () => {
+  expect(renderTemplate("A\n\n\n{{x}}\n\nB", { x: "" })).toBe("A\n\nB");
+});
+
+test("validateTemplate flags unknown tokens for the type", () => {
+  expect(validateTemplate("request.created", "{{title}} {{linkUrl}}")).toEqual([]);
+  expect(
+    validateTemplate("request.created", "{{title}} {{bogus}} {{joinUrl}}").sort(),
+  ).toEqual(["bogus", "joinUrl"]);
+});

--- a/apps/console/src/data/notification-templates-core.ts
+++ b/apps/console/src/data/notification-templates-core.ts
@@ -48,65 +48,71 @@ export function escapeHtml(text: string): string {
 // builders, which never escaped URLs). Everything else is escaped.
 const RAW_TOKEN_NAMES = new Set(["linkUrl", "streamUrl", "joinUrl"]);
 
+function specs(...names: string[]): readonly TokenSpec[] {
+  return names.map((name) =>
+    RAW_TOKEN_NAMES.has(name) ? { name, raw: true } : { name },
+  );
+}
+
+// Tokens are grouped by *category*: every message type in a category
+// shares the same composable field set (e.g. all request events expose
+// the full request record). They need not all be used by the default
+// template — they exist so admins can compose whatever they want. The
+// matching values are resolved server-side in server/notifications/
+// enrich.ts (full DB row) with the event payload as fallback.
+
+const REQUEST_TOKENS = specs(
+  "title", "status", "priority", "category", "requesterName", "requestedBy",
+  "dueDate", "createdAt", "updatedAt", "trackingCode",
+  "who", "what", "whenText", "whereText", "why", "how", "notes", "flow",
+  "linkUrl",
+);
+
+const BOOKING_TOKENS = specs(
+  "title", "status", "requesterName", "bookedBy",
+  "checkedOutAt", "expectedReturnAt", "returnedAt", "notes", "trackingCode",
+  "itemCount", "equipmentName", "equipmentNames",
+  "equipmentCategory", "equipmentLocation", "equipmentSerial",
+  "linkUrl",
+);
+
+const STREAM_TOKENS = specs(
+  "title", "description", "scheduledStartTime", "actualStartTime",
+  "status", "privacyStatus", "isForKids", "latencyPreference", "tags",
+  "createdAt", "streamUrl",
+);
+
+const MEETING_TOKENS = specs(
+  "topic", "description", "startTime", "duration", "timezone",
+  "meetingType", "waitingRoom", "recurrenceType", "createdAt", "joinUrl",
+);
+
+const CUE_TOKENS = specs(
+  "title", "eventName", "eventDescription", "eventScheduledAt", "eventDuration",
+  "trackName", "cueStart", "cueDuration", "cueType", "cueNotes",
+  "duty", "assigneeName", "linkUrl",
+);
+
+const CHECKLIST_TOKENS = specs(
+  "title", "checklistName", "checklistDescription", "checklistScheduledAt",
+  "sectionName", "itemChecked", "duty", "assigneeName", "linkUrl",
+);
+
 export const TEMPLATE_TOKENS: Record<MessageType, readonly TokenSpec[]> = {
-  "stream.created": [
-    { name: "title" },
-    { name: "scheduledStartTime" },
-    { name: "streamUrl", raw: true },
-  ],
-  "meeting.created": [
-    { name: "topic" },
-    { name: "startTime" },
-    { name: "joinUrl", raw: true },
-  ],
-  "request.created": [
-    { name: "title" },
-    { name: "status" },
-    { name: "requesterName" },
-    { name: "linkUrl", raw: true },
-  ],
-  "request.status_changed": [
-    { name: "title" },
-    { name: "status" },
-    { name: "requesterName" },
-    { name: "linkUrl", raw: true },
-  ],
-  "request.archived": [
-    { name: "title" },
-    { name: "requesterName" },
-    { name: "linkUrl", raw: true },
-  ],
-  "booking.created": [
-    { name: "title" },
-    { name: "status" },
-    { name: "requesterName" },
-    { name: "linkUrl", raw: true },
-  ],
-  "booking.status_changed": [
-    { name: "title" },
-    { name: "status" },
-    { name: "linkUrl", raw: true },
-  ],
-  "assignment.request": [
-    { name: "title" },
-    { name: "duty" },
-    { name: "assigneeName" },
-    { name: "linkUrl", raw: true },
-  ],
-  "assignment.cue": [
-    { name: "title" },
-    { name: "eventName" },
-    { name: "duty" },
-    { name: "assigneeName" },
-    { name: "linkUrl", raw: true },
-  ],
-  "assignment.checklist_item": [
-    { name: "title" },
-    { name: "checklistName" },
-    { name: "duty" },
-    { name: "assigneeName" },
-    { name: "linkUrl", raw: true },
-  ],
+  "stream.created": STREAM_TOKENS,
+  "meeting.created": MEETING_TOKENS,
+  "request.created": REQUEST_TOKENS,
+  "request.status_changed": REQUEST_TOKENS,
+  "request.archived": REQUEST_TOKENS,
+  "booking.created": BOOKING_TOKENS,
+  "booking.status_changed": BOOKING_TOKENS,
+  // Request assignment shares the request category, plus the DM-only
+  // duty / assignee fields.
+  "assignment.request": specs(
+    ...REQUEST_TOKENS.map((t) => t.name), "duty", "assigneeName",
+  ),
+  "assignment.cue": CUE_TOKENS,
+  "assignment.checklist_item": CHECKLIST_TOKENS,
 };
 
 // Friendly built-in wording with a modest amount of emoji. These are
@@ -116,25 +122,25 @@ export const TEMPLATE_TOKENS: Record<MessageType, readonly TokenSpec[]> = {
 // fields collapse cleanly — see renderTemplate + the core tests.
 export const DEFAULT_TEMPLATES: Record<MessageType, string> = {
   "stream.created":
-    "🔴 <b>We're going live on YouTube</b>\n\n{{title}}\n🗓 Starts {{scheduledStartTime}}\n\n🔗 <a href=\"{{streamUrl}}\">Watch the stream</a>",
+    "✨ <b>New YouTube Stream scheduled</b>\n\n📌 <b>Title:</b> {{title}}\n🗓 <b>Scheduled:</b> Starts {{scheduledStartTime}}\n\n🔗 <a href=\"{{streamUrl}}\">Watch the stream</a>",
   "meeting.created":
-    "📅 <b>New Zoom meeting scheduled</b>\n\n{{topic}}\n🗓 Starts {{startTime}}\n\n🔗 <a href=\"{{joinUrl}}\">Join the meeting</a>",
+    "✨ <b>New Zoom meeting scheduled</b>\n\n📌 <b>Title:</b> {{topic}}\n🗓 <b>Scheduled:</b> Starts {{startTime}}\n\n🔗 <a href=\"{{joinUrl}}\">Join the meeting</a>",
   "request.created":
-    "✨ <b>New request just came in</b>\n\n{{title}}\n🙋 From {{requesterName}}\n📌 Status: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
+    "✨ <b>New request just came in</b>\n\n📌 <b>Title:</b> {{title}}\n🙋 <b>From:</b> {{requesterName}}\n🗂️ <b>Category:</b> {{category}}\n🎯 <b>Priority:</b> {{priority}}\n📅 <b>Due:</b> {{dueDate}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
   "request.status_changed":
-    "🔄 <b>Request status updated</b>\n\n{{title}}\n📌 Now: <i>{{status}}</i>\n🙋 From {{requesterName}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
+    "📣 <b>Request status updated</b>\n\n📌 <b>Title:</b> {{title}}\n🔄 Now: <i>{{status}}</i>\n🙋 <b>From:</b> {{requesterName}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
   "request.archived":
-    "🗄️ <b>Request archived</b>\n\n{{title}}\n🙋 From {{requesterName}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
+    "📣 <b>Request archived</b>\n\n📌 <b>Title:</b> {{title}}\n🙋 <b>From:</b> {{requesterName}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
   "booking.created":
-    "🎒 <b>New equipment booking</b>\n\n{{title}}\n🙋 From {{requesterName}}\n📌 Status: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the booking</a>",
+    "✨ <b>New equipment booking</b>\n\n📌 <b>Title:</b> {{title}}\n🙋 <b>From:</b> {{requesterName}}\n🔄 <b>Status:</b> <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the booking</a>",
   "booking.status_changed":
-    "🔄 <b>Equipment booking updated</b>\n\n{{title}}\n📌 Now: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the booking</a>",
+    "📣 <b>Equipment booking updated</b>\n\n📌 <b>Title:</b> {{title}}\n🔄 Now: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the booking</a>",
   "assignment.request":
-    "👋 Hey {{assigneeName}}!\n🎯 <b>You've been assigned to a request</b>\n\n{{title}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Request Details</a>",
+    "👋 Hey {{assigneeName}}!\nYou've been assigned to a request\n\n📌 <b>Title:</b> {{title}}\n🛠 <b>Duty:</b> <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Request Details</a>",
   "assignment.cue":
-    "👋 Hey {{assigneeName}}!\n🎬 <b>You've been assigned to a cue</b>\n\n{{title}}\n📋 Event: {{eventName}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Event Details</a>",
+    "👋 Hey {{assigneeName}}!\nYou've been assigned to a cue\n\n📌 <b>Title:</b> {{title}}\n📋 <b>Event:</b> {{eventName}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Event Details</a>",
   "assignment.checklist_item":
-    "👋 Hey {{assigneeName}}!\n✅ <b>You've been assigned to a checklist item</b>\n\n{{title}}\n📋 Checklist: {{checklistName}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Checklist Details</a>",
+    "👋 Hey {{assigneeName}}!\nYou've been assigned to a checklist item\n\n📌 <b>Title:</b> {{title}}\n📋 <b>Checklist:</b> {{checklistName}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Checklist Details</a>",
 };
 
 export type TokenValues = Record<string, string | null | undefined>;
@@ -193,54 +199,96 @@ export function validateTemplate(type: MessageType, body: string): string[] {
 
 // Sample data for the settings live-preview. Values are intentionally
 // realistic so admins see escaping behaviour (e.g. the & in a title).
+const REQUEST_SAMPLE: TokenValues = {
+  title: "Lower-third graphic for guest speaker",
+  status: "in progress",
+  priority: "High",
+  category: "Graphics",
+  requesterName: "Tendai M.",
+  requestedBy: "Tendai M.",
+  dueDate: "Wed, 21 May 2026 17:00:00 GMT",
+  createdAt: "Mon, 18 May 2026 08:12:00 GMT",
+  updatedAt: "Mon, 18 May 2026 09:30:00 GMT",
+  trackingCode: "REQ-4F2A9C",
+  who: "Guest speaker — Dr. A. Banda",
+  what: "Name + title lower-third for the 2nd session",
+  whenText: "Sunday 2nd service",
+  whereText: "Main auditorium",
+  why: "Introduce the guest on screen",
+  how: "Match the current sermon series template",
+  notes: "Spelling confirmed with the office",
+  flow: "Session 2 → after worship",
+  linkUrl: "https://app.example.com/requests/123",
+};
+
+const BOOKING_SAMPLE: TokenValues = {
+  title: "Booking BKG-77C1 (3 items)",
+  status: "booked",
+  requesterName: "Rumbi K.",
+  bookedBy: "Rumbi K.",
+  checkedOutAt: "Fri, 22 May 2026 07:00:00 GMT",
+  expectedReturnAt: "Sun, 24 May 2026 20:00:00 GMT",
+  returnedAt: "",
+  notes: "Outside shoot — handle with care",
+  trackingCode: "BKG-77C1",
+  itemCount: "3",
+  equipmentName: "Sony FX6",
+  equipmentNames: "Sony FX6, Sennheiser MKH-416, Manfrotto tripod",
+  equipmentCategory: "Camera",
+  equipmentLocation: "Store room B, shelf 2",
+  equipmentSerial: "FX6-99213",
+  linkUrl: "https://app.example.com/equipment/bookings",
+};
+
+// Sample data for the settings live-preview. Values are intentionally
+// realistic so admins see escaping behaviour (e.g. the & in a title).
 export const SAMPLE_TOKENS: Record<MessageType, TokenValues> = {
   "stream.created": {
     title: "Sunday Service — Worship & Word",
+    description: "Live broadcast of the 2nd service",
     scheduledStartTime: "Sun, 18 May 2026 09:00:00 GMT",
+    actualStartTime: "",
+    status: "created",
+    privacyStatus: "unlisted",
+    isForKids: "No",
+    latencyPreference: "normal",
+    tags: "service, worship, live",
+    createdAt: "Sat, 17 May 2026 18:40:00 GMT",
     streamUrl: "https://youtube.com/watch?v=abc123",
   },
   "meeting.created": {
     topic: "Production Team Sync",
+    description: "Weekly run-through and assignments",
     startTime: "Mon, 19 May 2026 14:00:00 GMT",
+    duration: "60 min",
+    timezone: "Africa/Harare",
+    meetingType: "scheduled",
+    waitingRoom: "On",
+    recurrenceType: "weekly",
+    createdAt: "Mon, 12 May 2026 11:00:00 GMT",
     joinUrl: "https://zoom.us/j/123456789",
   },
-  "request.created": {
-    title: "Lower-third graphic for guest speaker",
-    status: "not started",
-    requesterName: "Tendai M.",
-    linkUrl: "https://app.example.com/requests/123",
-  },
-  "request.status_changed": {
-    title: "Lower-third graphic for guest speaker",
-    status: "in progress",
-    requesterName: "Tendai M.",
-    linkUrl: "https://app.example.com/requests/123",
-  },
-  "request.archived": {
-    title: "Lower-third graphic for guest speaker",
-    requesterName: "Tendai M.",
-    linkUrl: "https://app.example.com/requests/123",
-  },
-  "booking.created": {
-    title: "Sony FX6 + tripod",
-    status: "pending",
-    requesterName: "Rumbi K.",
-    linkUrl: "https://app.example.com/bookings/45",
-  },
+  "request.created": { ...REQUEST_SAMPLE, status: "not started" },
+  "request.status_changed": REQUEST_SAMPLE,
+  "request.archived": { ...REQUEST_SAMPLE, status: "archived" },
+  "booking.created": BOOKING_SAMPLE,
   "booking.status_changed": {
-    title: "Sony FX6 + tripod",
-    status: "approved",
-    linkUrl: "https://app.example.com/bookings/45",
+    ...BOOKING_SAMPLE,
+    status: "returned",
+    returnedAt: "Sun, 24 May 2026 19:30:00 GMT",
   },
-  "assignment.request": {
-    title: "Lower-third graphic for guest speaker",
-    duty: "Design",
-    assigneeName: "Craig C.",
-    linkUrl: "https://app.example.com/requests/123",
-  },
+  "assignment.request": { ...REQUEST_SAMPLE, duty: "Design", assigneeName: "Craig C." },
   "assignment.cue": {
     title: "Roll opening VT",
     eventName: "Sunday Service",
+    eventDescription: "2nd service — full programme",
+    eventScheduledAt: "Sun, 18 May 2026 09:00:00 GMT",
+    eventDuration: "120 min",
+    trackName: "Vision Mixing",
+    cueStart: "00:05:30",
+    cueDuration: "00:01:15",
+    cueType: "Video",
+    cueNotes: "Fade audio under at the end",
     duty: "Playback",
     assigneeName: "Craig C.",
     linkUrl: "https://app.example.com/cue-sheet/events/77",
@@ -248,6 +296,10 @@ export const SAMPLE_TOKENS: Record<MessageType, TokenValues> = {
   "assignment.checklist_item": {
     title: "Check radio mic batteries",
     checklistName: "Pre-service audio",
+    checklistDescription: "Audio readiness for the 2nd service",
+    checklistScheduledAt: "Sun, 18 May 2026 08:00:00 GMT",
+    sectionName: "Microphones",
+    itemChecked: "No",
     duty: "Audio",
     assigneeName: "Craig C.",
     linkUrl: "https://app.example.com/cue-sheet/checklist/9",

--- a/apps/console/src/data/notification-templates-core.ts
+++ b/apps/console/src/data/notification-templates-core.ts
@@ -1,0 +1,262 @@
+// Pure, dependency-free template engine for Telegram notifications.
+// Imported by BOTH the server (dispatch.ts / assignment.ts) and the
+// settings UI (live preview), so it must stay free of Node and React.
+//
+// A template is plain text with {{token}} placeholders plus literal
+// Telegram HTML (<b> <i> <a>). Only token *values* are HTML-escaped
+// (URL tokens excepted — see RAW_TOKENS); the literal text passes
+// through untouched. A line that contains tokens which ALL resolve
+// empty is dropped, reproducing the old `if (x) lines.push(...)`
+// behaviour. With no custom row stored, callers render
+// DEFAULT_TEMPLATES, which is byte-identical to the legacy hardcoded
+// output (see notification-templates-core.test.ts).
+
+import type { NotificationEventKey } from "./notification-events";
+
+export type TemplateScope = "group" | "dm";
+
+export type DmMessageType =
+  | "assignment.request"
+  | "assignment.cue"
+  | "assignment.checklist_item";
+
+export type MessageType = NotificationEventKey | DmMessageType;
+
+export const DM_MESSAGE_TYPES: readonly DmMessageType[] = [
+  "assignment.request",
+  "assignment.cue",
+  "assignment.checklist_item",
+];
+
+export function scopeForMessageType(type: MessageType): TemplateScope {
+  return (DM_MESSAGE_TYPES as readonly string[]).includes(type) ? "dm" : "group";
+}
+
+export type TokenSpec = { name: string; raw?: boolean };
+
+// Telegram's HTML parser only special-cases &, <, > — quotes don't
+// need escaping. Identical to the (now-removed) copies in dispatch.ts
+// and assignment.ts; kept here as the single source of truth.
+export function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+// URL tokens are interpolated raw into href="..." (matching the legacy
+// builders, which never escaped URLs). Everything else is escaped.
+const RAW_TOKEN_NAMES = new Set(["linkUrl", "streamUrl", "joinUrl"]);
+
+export const TEMPLATE_TOKENS: Record<MessageType, readonly TokenSpec[]> = {
+  "stream.created": [
+    { name: "title" },
+    { name: "scheduledStartTime" },
+    { name: "streamUrl", raw: true },
+  ],
+  "meeting.created": [
+    { name: "topic" },
+    { name: "startTime" },
+    { name: "joinUrl", raw: true },
+  ],
+  "request.created": [
+    { name: "title" },
+    { name: "status" },
+    { name: "requesterName" },
+    { name: "linkUrl", raw: true },
+  ],
+  "request.status_changed": [
+    { name: "title" },
+    { name: "status" },
+    { name: "requesterName" },
+    { name: "linkUrl", raw: true },
+  ],
+  "request.archived": [
+    { name: "title" },
+    { name: "requesterName" },
+    { name: "linkUrl", raw: true },
+  ],
+  "booking.created": [
+    { name: "title" },
+    { name: "status" },
+    { name: "requesterName" },
+    { name: "linkUrl", raw: true },
+  ],
+  "booking.status_changed": [
+    { name: "title" },
+    { name: "status" },
+    { name: "linkUrl", raw: true },
+  ],
+  "assignment.request": [
+    { name: "title" },
+    { name: "duty" },
+    { name: "assigneeName" },
+    { name: "linkUrl", raw: true },
+  ],
+  "assignment.cue": [
+    { name: "title" },
+    { name: "eventName" },
+    { name: "duty" },
+    { name: "assigneeName" },
+    { name: "linkUrl", raw: true },
+  ],
+  "assignment.checklist_item": [
+    { name: "title" },
+    { name: "checklistName" },
+    { name: "duty" },
+    { name: "assigneeName" },
+    { name: "linkUrl", raw: true },
+  ],
+};
+
+// Friendly built-in wording with a modest amount of emoji. These are
+// the fallback messages when a workspace has not set a custom template.
+// Keep every line either token-free (always shown) or driven by a
+// single token (auto-dropped when that token is empty) so optional
+// fields collapse cleanly — see renderTemplate + the core tests.
+export const DEFAULT_TEMPLATES: Record<MessageType, string> = {
+  "stream.created":
+    "🔴 <b>We're going live on YouTube</b>\n\n{{title}}\n🗓 Starts {{scheduledStartTime}}\n\n🔗 <a href=\"{{streamUrl}}\">Watch the stream</a>",
+  "meeting.created":
+    "📅 <b>New Zoom meeting scheduled</b>\n\n{{topic}}\n🗓 Starts {{startTime}}\n\n🔗 <a href=\"{{joinUrl}}\">Join the meeting</a>",
+  "request.created":
+    "✨ <b>New request just came in</b>\n\n{{title}}\n🙋 From {{requesterName}}\n📌 Status: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
+  "request.status_changed":
+    "🔄 <b>Request status updated</b>\n\n{{title}}\n📌 Now: <i>{{status}}</i>\n🙋 From {{requesterName}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
+  "request.archived":
+    "🗄️ <b>Request archived</b>\n\n{{title}}\n🙋 From {{requesterName}}\n\n🔗 <a href=\"{{linkUrl}}\">Open the request</a>",
+  "booking.created":
+    "🎒 <b>New equipment booking</b>\n\n{{title}}\n🙋 From {{requesterName}}\n📌 Status: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the booking</a>",
+  "booking.status_changed":
+    "🔄 <b>Equipment booking updated</b>\n\n{{title}}\n📌 Now: <i>{{status}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">Open the booking</a>",
+  "assignment.request":
+    "👋 Hey {{assigneeName}}!\n🎯 <b>You've been assigned to a request</b>\n\n{{title}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Request Details</a>",
+  "assignment.cue":
+    "👋 Hey {{assigneeName}}!\n🎬 <b>You've been assigned to a cue</b>\n\n{{title}}\n📋 Event: {{eventName}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Event Details</a>",
+  "assignment.checklist_item":
+    "👋 Hey {{assigneeName}}!\n✅ <b>You've been assigned to a checklist item</b>\n\n{{title}}\n📋 Checklist: {{checklistName}}\n🛠 Duty: <i>{{duty}}</i>\n\n🔗 <a href=\"{{linkUrl}}\">View Full Checklist Details</a>",
+};
+
+export type TokenValues = Record<string, string | null | undefined>;
+
+const TOKEN_RE = /\{\{(\w+)\}\}/g;
+
+function isEmpty(value: string | null | undefined): boolean {
+  return value == null || value === "";
+}
+
+function resolveToken(name: string, value: string | null | undefined): string {
+  if (isEmpty(value)) return "";
+  return RAW_TOKEN_NAMES.has(name) ? (value as string) : escapeHtml(value as string);
+}
+
+/**
+ * Render a template against resolved token values.
+ *
+ * - {{token}} → escaped value (raw for URL tokens); unknown/empty → "".
+ * - Literal text (incl. <b>/<i>/<a>) passes through untouched.
+ * - A line whose tokens ALL resolve empty is dropped entirely.
+ * - Runs of blank lines collapse to one; leading/trailing blanks trimmed.
+ */
+export function renderTemplate(body: string, values: TokenValues): string {
+  const kept: string[] = [];
+
+  for (const line of body.split("\n")) {
+    const tokens = [...line.matchAll(TOKEN_RE)];
+    if (tokens.length > 0 && tokens.every((m) => isEmpty(values[m[1]]))) {
+      continue; // every token on this line is empty → drop the line
+    }
+    kept.push(line.replace(TOKEN_RE, (_, name: string) => resolveToken(name, values[name])));
+  }
+
+  // Collapse consecutive blanks and trim leading/trailing blank lines.
+  const out: string[] = [];
+  for (const line of kept) {
+    const blank = line.trim() === "";
+    if (blank && (out.length === 0 || out[out.length - 1].trim() === "")) continue;
+    out.push(line);
+  }
+  while (out.length > 0 && out[out.length - 1].trim() === "") out.pop();
+
+  return out.join("\n");
+}
+
+/** Token names referenced by a template that are not valid for `type`. */
+export function validateTemplate(type: MessageType, body: string): string[] {
+  const valid = new Set(TEMPLATE_TOKENS[type].map((t) => t.name));
+  const unknown = new Set<string>();
+  for (const m of body.matchAll(TOKEN_RE)) {
+    if (!valid.has(m[1])) unknown.add(m[1]);
+  }
+  return [...unknown];
+}
+
+// Sample data for the settings live-preview. Values are intentionally
+// realistic so admins see escaping behaviour (e.g. the & in a title).
+export const SAMPLE_TOKENS: Record<MessageType, TokenValues> = {
+  "stream.created": {
+    title: "Sunday Service — Worship & Word",
+    scheduledStartTime: "Sun, 18 May 2026 09:00:00 GMT",
+    streamUrl: "https://youtube.com/watch?v=abc123",
+  },
+  "meeting.created": {
+    topic: "Production Team Sync",
+    startTime: "Mon, 19 May 2026 14:00:00 GMT",
+    joinUrl: "https://zoom.us/j/123456789",
+  },
+  "request.created": {
+    title: "Lower-third graphic for guest speaker",
+    status: "not started",
+    requesterName: "Tendai M.",
+    linkUrl: "https://app.example.com/requests/123",
+  },
+  "request.status_changed": {
+    title: "Lower-third graphic for guest speaker",
+    status: "in progress",
+    requesterName: "Tendai M.",
+    linkUrl: "https://app.example.com/requests/123",
+  },
+  "request.archived": {
+    title: "Lower-third graphic for guest speaker",
+    requesterName: "Tendai M.",
+    linkUrl: "https://app.example.com/requests/123",
+  },
+  "booking.created": {
+    title: "Sony FX6 + tripod",
+    status: "pending",
+    requesterName: "Rumbi K.",
+    linkUrl: "https://app.example.com/bookings/45",
+  },
+  "booking.status_changed": {
+    title: "Sony FX6 + tripod",
+    status: "approved",
+    linkUrl: "https://app.example.com/bookings/45",
+  },
+  "assignment.request": {
+    title: "Lower-third graphic for guest speaker",
+    duty: "Design",
+    assigneeName: "Craig C.",
+    linkUrl: "https://app.example.com/requests/123",
+  },
+  "assignment.cue": {
+    title: "Roll opening VT",
+    eventName: "Sunday Service",
+    duty: "Playback",
+    assigneeName: "Craig C.",
+    linkUrl: "https://app.example.com/cue-sheet/events/77",
+  },
+  "assignment.checklist_item": {
+    title: "Check radio mic batteries",
+    checklistName: "Pre-service audio",
+    duty: "Audio",
+    assigneeName: "Craig C.",
+    linkUrl: "https://app.example.com/cue-sheet/checklist/9",
+  },
+};
+
+// Human labels for the settings UI.
+export const DM_MESSAGE_LABELS: Record<DmMessageType, string> = {
+  "assignment.request": "Request assignment",
+  "assignment.cue": "Cue assignment",
+  "assignment.checklist_item": "Checklist item assignment",
+};

--- a/apps/console/src/data/notification-templates.ts
+++ b/apps/console/src/data/notification-templates.ts
@@ -1,0 +1,90 @@
+import { supabase } from "@moc/data/supabase";
+import type { MessageType, TemplateScope } from "./notification-templates-core";
+
+export type NotificationTemplate = {
+  id: string;
+  workspaceId: string;
+  scope: TemplateScope;
+  messageType: MessageType;
+  body: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type Row = {
+  id: string;
+  workspace_id: string;
+  scope: string;
+  message_type: string;
+  body: string;
+  created_at: string;
+  updated_at: string;
+};
+
+function rowToTemplate(row: Row): NotificationTemplate {
+  return {
+    id: row.id,
+    workspaceId: row.workspace_id,
+    scope: row.scope as TemplateScope,
+    messageType: row.message_type as MessageType,
+    body: row.body,
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  };
+}
+
+const COLUMNS = "id, workspace_id, scope, message_type, body, created_at, updated_at";
+
+export async function fetchNotificationTemplates(
+  workspaceId: string,
+): Promise<NotificationTemplate[]> {
+  const { data, error } = await supabase
+    .from("notification_message_templates")
+    .select(COLUMNS)
+    .eq("workspace_id", workspaceId);
+
+  if (error) throw new Error(error.message);
+  return ((data ?? []) as Row[]).map(rowToTemplate);
+}
+
+export async function upsertNotificationTemplate(params: {
+  workspaceId: string;
+  scope: TemplateScope;
+  messageType: MessageType;
+  body: string;
+}): Promise<NotificationTemplate> {
+  const { data, error } = await supabase
+    .from("notification_message_templates")
+    .upsert(
+      {
+        workspace_id: params.workspaceId,
+        scope: params.scope,
+        message_type: params.messageType,
+        body: params.body,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: "workspace_id,scope,message_type" },
+    )
+    .select(COLUMNS)
+    .single();
+
+  if (error) throw new Error(error.message);
+  return rowToTemplate(data as Row);
+}
+
+// "Restore default" — removing the row makes the renderer fall back to
+// DEFAULT_TEMPLATES. No-op if no custom row exists.
+export async function deleteNotificationTemplate(params: {
+  workspaceId: string;
+  scope: TemplateScope;
+  messageType: MessageType;
+}): Promise<void> {
+  const { error } = await supabase
+    .from("notification_message_templates")
+    .delete()
+    .eq("workspace_id", params.workspaceId)
+    .eq("scope", params.scope)
+    .eq("message_type", params.messageType);
+
+  if (error) throw new Error(error.message);
+}

--- a/apps/console/src/features/broadcast/integration-card.tsx
+++ b/apps/console/src/features/broadcast/integration-card.tsx
@@ -2,7 +2,7 @@ import { Button } from "@moc/ui/components/controls/button"
 import { Label, Paragraph } from "@moc/ui/components/display/text"
 import { Badge } from "@moc/ui/components/display/badge"
 import { LoadingSpinner } from "@moc/ui/components/feedback/spinner"
-import { Link2, Unlink } from "lucide-react"
+import { Link2, RefreshCw, Unlink } from "lucide-react"
 import type { ReactNode } from "react"
 
 type IntegrationCardProps = {
@@ -16,9 +16,12 @@ type IntegrationCardProps = {
   onConnect: () => void
   onDisconnect: () => void
   isDisconnecting: boolean
+  // Connected but the stored authorization is dead — surface a
+  // Reconnect affordance instead of a healthy "Connected" state.
+  needsReauth?: boolean
 }
 
-export function IntegrationCard({ icon, name, description, isLoading, isConnected, accountLabel, canManage, onConnect, onDisconnect, isDisconnecting }: IntegrationCardProps) {
+export function IntegrationCard({ icon, name, description, isLoading, isConnected, accountLabel, canManage, onConnect, onDisconnect, isDisconnecting, needsReauth = false }: IntegrationCardProps) {
   if (isLoading) {
     return (
       <LoadingSpinner className="py-6 border border-tertiary rounded-lg" />
@@ -35,7 +38,14 @@ export function IntegrationCard({ icon, name, description, isLoading, isConnecte
           <Label.sm>{isConnected ? accountLabel ?? name : name}</Label.sm>
           <div className="flex items-center gap-1.5">
             {isConnected ? (
-              <Badge label="Connected" color="green" />
+              needsReauth ? (
+                <>
+                  <Badge label="Reconnect required" color="red" />
+                  <Paragraph.xs className="text-quaternary">Authorization expired</Paragraph.xs>
+                </>
+              ) : (
+                <Badge label="Connected" color="green" />
+              )
             ) : (
               <>
                 <Badge label="Not connected" color="gray" />
@@ -48,14 +58,25 @@ export function IntegrationCard({ icon, name, description, isLoading, isConnecte
 
       {canManage && (
         isConnected ? (
-          <Button
-            variant="danger-secondary"
-            onClick={onDisconnect}
-            disabled={isDisconnecting}
-            icon={<Unlink className="size-4" />}
-          >
-            {isDisconnecting ? "Disconnecting..." : "Disconnect"}
-          </Button>
+          <div className="flex items-center gap-2 shrink-0">
+            {needsReauth && (
+              <Button
+                variant="primary"
+                onClick={onConnect}
+                icon={<RefreshCw className="size-4" />}
+              >
+                Reconnect
+              </Button>
+            )}
+            <Button
+              variant="danger-secondary"
+              onClick={onDisconnect}
+              disabled={isDisconnecting}
+              icon={<Unlink className="size-4" />}
+            >
+              {isDisconnecting ? "Disconnecting..." : "Disconnect"}
+            </Button>
+          </div>
         ) : (
           <Button
             variant="primary"

--- a/apps/console/src/features/broadcast/stream-modal.tsx
+++ b/apps/console/src/features/broadcast/stream-modal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react"
+import { useCallback, useEffect, useRef, useState } from "react"
 import type { ChangeEvent } from "react"
 import { Modal } from "@moc/ui/components/overlays/modal"
 import { Button } from "@moc/ui/components/controls/button"
@@ -8,12 +8,13 @@ import { Accordion } from "@moc/ui/components/display/accordion"
 import type { Stream, StreamPreset, StreamPrivacy, LatencyPreference, YouTubeCategory, YouTubePlaylist } from "@moc/types/broadcast/stream"
 import type { MediaItem } from "@moc/types/broadcast/media-item"
 import type { ThumbnailSource } from "@/data/mutate-streams"
+import { fetchImageBlob, UNFETCHABLE_THUMBNAIL_MESSAGE } from "@moc/utils/blob-fetch"
 import { fetchCategories, fetchPlaylists } from "@/data/fetch-streams"
 import { fetchMedia } from "@/data/fetch-broadcast"
 import { useFeedback } from "@moc/ui/components/feedback/feedback-provider"
 import { formatUtcIsoForDateTimeInput, parseDateTimeInputToUtcIso } from "@moc/utils/zoned-date-time"
 import { StreamBasicFields } from "./stream-basic-fields"
-import { StreamThumbnailField } from "./stream-thumbnail-field"
+import { StreamThumbnailField, type ThumbnailStatus } from "./stream-thumbnail-field"
 import { StreamOptionsSection } from "./stream-options-section"
 import { StreamAdvancedSection } from "./stream-advanced-section"
 
@@ -54,7 +55,12 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
   // In create mode, seed state from the workspace preset (if any).
   const seed = stream ?? preset ?? null
   const seedScheduledStart = stream ? stream.scheduledStartTime : preset?.scheduledStartTime ?? null
-  const seedThumbnailUrl = stream ? stream.thumbnailUrl ?? null : preset?.thumbnailUrl ?? null
+  // A preset thumbnail is a pending source to re-apply to the new stream. A
+  // stream's existing thumbnail (edit mode) is display-only — we never re-fetch
+  // and re-upload it, so editing other fields can't be blocked by a YouTube CDN
+  // URL we can't read.
+  const presetThumbnailUrl = !isEditing ? preset?.thumbnailUrl ?? null : null
+  const fileNameFromUrl = (url: string, fallback: string) => url.split("/").pop() || fallback
 
   // ─── Basic fields ──────────────────────────────────────
   const [title, setTitle] = useState(seed?.title ?? "")
@@ -67,14 +73,27 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
   const [savePreset, setSavePreset] = useState(false)
 
   // ─── Thumbnail ─────────────────────────────────────────
-  const [thumbnail, setThumbnail] = useState<ThumbnailSource>(
-    seedThumbnailUrl ? { type: "url", url: seedThumbnailUrl } : null,
+  // The user's chosen source. Bytes are resolved + validated here (in
+  // `thumbBlob`) before submit; the data layer never fetches a URL itself.
+  type ThumbSelection =
+    | { kind: "file"; file: File }
+    | { kind: "url"; url: string }
+    | { kind: "media"; url: string }
+    | null
+  const [thumbSelection, setThumbSelection] = useState<ThumbSelection>(
+    presetThumbnailUrl ? { kind: "url", url: presetThumbnailUrl } : null,
   )
-  const [thumbnailFileName, setThumbnailFileName] = useState<string | undefined>(
-    seedThumbnailUrl ? (seedThumbnailUrl.split("/").pop() || "Preset thumbnail") : undefined,
+  const [thumbName, setThumbName] = useState<string | undefined>(
+    presetThumbnailUrl ? fileNameFromUrl(presetThumbnailUrl, "Preset thumbnail") : undefined,
   )
+  const [thumbBlob, setThumbBlob] = useState<Blob | null>(null)
+  const [thumbStatus, setThumbStatus] = useState<ThumbnailStatus>("idle")
+  const [thumbError, setThumbError] = useState<string | null>(null)
+  const [thumbPreviewUrl, setThumbPreviewUrl] = useState<string | null>(null)
   const [thumbnailUrlInput, setThumbnailUrlInput] = useState("")
   const [thumbnailMode, setThumbnailMode] = useState<"file" | "url" | "media">("file")
+  // Discards results from a superseded resolution (e.g. paste URL A then B).
+  const resolveSeqRef = useRef(0)
 
   // ─── Category, tags, playlist ──────────────────────────
   const [categoryId, setCategoryId] = useState<string | null>(seed?.categoryId ?? null)
@@ -95,10 +114,15 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
   const [mediaItems, setMediaItems] = useState<MediaItem[]>([])
 
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const canSubmit = Boolean(title.trim()) && !isSubmitting
+  // Hard-gate Create on a validated thumbnail: a selected source must have
+  // resolved to bytes (never while resolving, never after a resolve failure).
+  const thumbReady = !thumbSelection || (thumbStatus === "ready" && thumbBlob !== null)
+  const canSubmit = Boolean(title.trim()) && !isSubmitting && thumbReady
 
-  // Filter media to only images (thumbnails must be images)
-  const imageMedia = mediaItems.filter((m) => m.type === "image")
+  // Thumbnails must be images, and must be fetchable as bytes. Items probed
+  // as unfetchable (blobFetchable === false) are hidden; legacy/unprobed
+  // (null) stay selectable and are re-validated on selection.
+  const imageMedia = mediaItems.filter((m) => m.type === "image" && m.blobFetchable !== false)
 
   // Fetch categories, playlists, and media when modal opens.
   // Collect failures and surface a single toast so a network outage doesn't
@@ -149,10 +173,59 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
     }
   }, [latencyPreference])
 
+  // Resolve the selected thumbnail to bytes whenever the selection changes
+  // (seeded preset on open, mode switch, URL confirm, media pick). Each run
+  // owns exactly one preview object URL and revokes it on cleanup; a stale
+  // resolution (selection changed mid-fetch) is discarded via the seq guard.
+  useEffect(() => {
+    const sel = thumbSelection
+    if (!sel) {
+      setThumbBlob(null)
+      setThumbStatus("idle")
+      setThumbError(null)
+      setThumbPreviewUrl(null)
+      return
+    }
+    const seq = ++resolveSeqRef.current
+
+    if (sel.kind === "file") {
+      const objUrl = URL.createObjectURL(sel.file)
+      setThumbBlob(sel.file)
+      setThumbStatus("ready")
+      setThumbError(null)
+      setThumbPreviewUrl(objUrl)
+      return () => URL.revokeObjectURL(objUrl)
+    }
+
+    setThumbStatus("resolving")
+    setThumbError(null)
+    setThumbBlob(null)
+    setThumbPreviewUrl(null)
+    let createdUrl: string | null = null
+    fetchImageBlob(sel.url)
+      .then((blob) => {
+        if (resolveSeqRef.current !== seq) return
+        createdUrl = URL.createObjectURL(blob)
+        setThumbBlob(blob)
+        setThumbStatus("ready")
+        setThumbPreviewUrl(createdUrl)
+      })
+      .catch(() => {
+        if (resolveSeqRef.current !== seq) return
+        setThumbBlob(null)
+        setThumbStatus("error")
+        setThumbError(UNFETCHABLE_THUMBNAIL_MESSAGE)
+        setThumbPreviewUrl(null)
+      })
+    return () => {
+      if (createdUrl) URL.revokeObjectURL(createdUrl)
+    }
+  }, [thumbSelection])
+
   const resetForm = useCallback(() => {
     const reset = stream ?? preset ?? null
     const resetScheduledStart = stream ? stream.scheduledStartTime : preset?.scheduledStartTime ?? null
-    const resetThumbnailUrl = stream ? stream.thumbnailUrl ?? null : preset?.thumbnailUrl ?? null
+    const resetPresetThumbUrl = !stream ? preset?.thumbnailUrl ?? null : null
     setTitle(reset?.title ?? "")
     setDescription(reset?.description ?? "")
     setPrivacyStatus(reset?.privacyStatus ?? "unlisted")
@@ -160,8 +233,9 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
     setScheduledStartTime(
       resetScheduledStart ? formatUtcIsoForDateTimeInput(resetScheduledStart, browserTimeZone) : "",
     )
-    setThumbnail(resetThumbnailUrl ? { type: "url", url: resetThumbnailUrl } : null)
-    setThumbnailFileName(resetThumbnailUrl ? (resetThumbnailUrl.split("/").pop() || "Current thumbnail") : undefined)
+    // The resolve effect re-derives blob/status/preview from the selection.
+    setThumbSelection(resetPresetThumbUrl ? { kind: "url", url: resetPresetThumbUrl } : null)
+    setThumbName(resetPresetThumbUrl ? (resetPresetThumbUrl.split("/").pop() || "Preset thumbnail") : undefined)
     setThumbnailUrlInput("")
     setThumbnailMode("file")
     setCategoryId(reset?.categoryId ?? null)
@@ -183,31 +257,30 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
 
   function handleFileSelect(file: File | null) {
     if (file) {
-      setThumbnail({ type: "file", file })
-      setThumbnailFileName(file.name)
+      setThumbSelection({ kind: "file", file })
+      setThumbName(file.name)
     } else {
-      setThumbnail(null)
-      setThumbnailFileName(undefined)
+      clearThumbnail()
     }
   }
 
   function handleThumbnailUrlConfirm() {
     const url = thumbnailUrlInput.trim()
     if (!url) return
-    setThumbnail({ type: "url", url })
-    setThumbnailFileName(url.split("/").pop() || "Image from URL")
+    setThumbSelection({ kind: "url", url })
+    setThumbName(url.split("/").pop() || "Image from URL")
   }
 
   function handleMediaSelect(mediaId: string) {
     const item = imageMedia.find((m) => m.id === mediaId)
     if (!item) return
-    setThumbnail({ type: "url", url: item.url })
-    setThumbnailFileName(item.name)
+    setThumbSelection({ kind: "media", url: item.url })
+    setThumbName(item.name)
   }
 
   function clearThumbnail() {
-    setThumbnail(null)
-    setThumbnailFileName(undefined)
+    setThumbSelection(null)
+    setThumbName(undefined)
     setThumbnailUrlInput("")
   }
 
@@ -237,6 +310,16 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
 
   async function handleSubmit() {
     if (!canSubmit) return
+
+    // Gate guarantees: if a source is selected it has resolved to bytes.
+    const thumbnail: ThumbnailSource =
+      thumbSelection && thumbBlob && thumbStatus === "ready"
+        ? {
+            blob: thumbBlob,
+            origin: thumbSelection.kind,
+            sourceUrl: thumbSelection.kind === "file" ? null : thumbSelection.url,
+          }
+        : null
 
     setIsSubmitting(true)
     try {
@@ -291,8 +374,13 @@ export function StreamModal({ open, onOpenChange, onSubmit, stream, preset }: St
 
                 {/* ─── Thumbnail ─── */}
                 <StreamThumbnailField
-                  thumbnail={thumbnail}
-                  thumbnailFileName={thumbnailFileName}
+                  hasSelection={thumbSelection !== null}
+                  selectionName={thumbName}
+                  previewUrl={
+                    thumbSelection ? thumbPreviewUrl : isEditing ? stream?.thumbnailUrl ?? null : null
+                  }
+                  status={thumbStatus}
+                  errorMessage={thumbError}
                   thumbnailUrlInput={thumbnailUrlInput}
                   thumbnailMode={thumbnailMode}
                   imageMedia={imageMedia}

--- a/apps/console/src/features/broadcast/stream-thumbnail-field.tsx
+++ b/apps/console/src/features/broadcast/stream-thumbnail-field.tsx
@@ -7,14 +7,21 @@ import { FileDropzone } from "@moc/ui/components/form/file-dropzone"
 import { Paragraph } from "@moc/ui/components/display/text"
 import { SegmentedControl } from "@moc/ui/components/controls/segmented-control"
 import type { MediaItem } from "@moc/types/broadcast/media-item"
-import type { ThumbnailSource } from "@/data/mutate-streams"
-import { Image, Link, X } from "lucide-react"
+import { Image, Link, Loader2, X } from "lucide-react"
 
 type ThumbnailMode = "file" | "url" | "media"
+export type ThumbnailStatus = "idle" | "resolving" | "ready" | "error"
 
 type StreamThumbnailFieldProps = {
-  thumbnail: ThumbnailSource
-  thumbnailFileName: string | undefined
+  // Whether the user has actively selected a new thumbnail (vs. just the
+  // stream's existing one shown for reference in edit mode).
+  hasSelection: boolean
+  selectionName: string | undefined
+  // Object URL of the resolved blob, or — in edit mode with no new
+  // selection — the stream's current thumbnail URL, for a static preview.
+  previewUrl: string | null
+  status: ThumbnailStatus
+  errorMessage: string | null
   thumbnailUrlInput: string
   thumbnailMode: ThumbnailMode
   imageMedia: MediaItem[]
@@ -27,8 +34,11 @@ type StreamThumbnailFieldProps = {
 }
 
 export function StreamThumbnailField({
-  thumbnail,
-  thumbnailFileName,
+  hasSelection,
+  selectionName,
+  previewUrl,
+  status,
+  errorMessage,
   thumbnailUrlInput,
   thumbnailMode,
   imageMedia,
@@ -43,16 +53,36 @@ export function StreamThumbnailField({
     <div className="flex flex-col gap-1.5">
       <FormLabel label="Thumbnail" optional />
 
-      {thumbnail ? (
-        <div className="flex items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-2">
-          {thumbnail.type === "url" && (
-            <img src={thumbnail.url} alt="" className="size-8 rounded object-cover shrink-0" />
+      {hasSelection ? (
+        <div className="flex flex-col gap-1">
+          <div className="flex items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-2">
+            {previewUrl && (
+              <img src={previewUrl} alt="" className="size-8 rounded object-cover shrink-0" />
+            )}
+            <Paragraph.sm className="text-secondary truncate flex-1">{selectionName}</Paragraph.sm>
+            {status === "resolving" && (
+              <Loader2 className="size-3.5 animate-spin text-quaternary shrink-0" />
+            )}
+            <Button.Icon variant="ghost" icon={<X className="size-3.5" />} onClick={onClear} />
+          </div>
+          {status === "resolving" && (
+            <Paragraph.xs className="text-quaternary">Checking image…</Paragraph.xs>
           )}
-          <Paragraph.sm className="text-secondary truncate flex-1">{thumbnailFileName}</Paragraph.sm>
-          <Button.Icon variant="ghost" icon={<X className="size-3.5" />} onClick={onClear} />
+          {status === "error" && errorMessage && (
+            <Paragraph.xs className="text-utility-red-700">{errorMessage}</Paragraph.xs>
+          )}
         </div>
       ) : (
         <div className="flex flex-col gap-2">
+          {previewUrl && (
+            <div className="flex items-center gap-2 rounded-lg border border-secondary bg-primary px-3 py-2">
+              <img src={previewUrl} alt="" className="size-8 rounded object-cover shrink-0" />
+              <Paragraph.sm className="text-quaternary truncate flex-1">
+                Current thumbnail — choose a source below to replace it.
+              </Paragraph.sm>
+            </div>
+          )}
+
           <SegmentedControl
             fill
             value={thumbnailMode}
@@ -67,7 +97,6 @@ export function StreamThumbnailField({
             <FileDropzone
               accept="image/jpeg,image/png"
               onFileSelect={onFileSelect}
-              fileName={thumbnailFileName}
               placeholder="Drop a thumbnail image or click to browse."
               selectedHint="Drop a new image or click to replace."
             />
@@ -105,9 +134,13 @@ export function StreamThumbnailField({
               </Select>
             ) : (
               <Paragraph.xs className="text-quaternary py-2">
-                No images found in your media library.
+                No usable images found in your media library.
               </Paragraph.xs>
             )
+          )}
+
+          {status === "error" && errorMessage && (
+            <Paragraph.xs className="text-utility-red-700">{errorMessage}</Paragraph.xs>
           )}
 
           <Paragraph.xs className="text-quaternary">

--- a/apps/console/src/features/broadcast/upload-media-modal.tsx
+++ b/apps/console/src/features/broadcast/upload-media-modal.tsx
@@ -11,6 +11,7 @@ import { FileDropzone } from "@moc/ui/components/form/file-dropzone"
 import { SegmentedControl } from "@moc/ui/components/controls/segmented-control"
 import { mediaTypeLabel } from "@moc/types/broadcast/constants"
 import { getDefaultMediaDetails, inferMediaTypeFromSource, probeMediaMetadata } from "@moc/utils/media-source"
+import { probeUrlFetchable } from "@moc/utils/blob-fetch"
 import { uploadMediaFile } from "@/data/mutate-broadcast"
 import { Link } from "lucide-react"
 
@@ -89,6 +90,16 @@ export function UploadMediaModal({ open, onOpenChange, onSubmit }: UploadMediaMo
         sourceMode === "url"
           ? url.trim()
           : await uploadMediaFile(file as File)
+      // Record whether this item's bytes are reachable, so the stream
+      // thumbnail picker can hide ones that would CORS-fail. Only meaningful
+      // for images (thumbnails must be images). Uploaded files live in our
+      // own CORS-safe Supabase bucket, so they're fetchable by construction;
+      // external image URLs are probed with a bounded first-chunk fetch.
+      let blobFetchable: boolean | null = null
+      if (inferredMediaType === "image") {
+        blobFetchable =
+          sourceMode === "upload" ? true : await probeUrlFetchable(sourceUrl)
+      }
       const mediaDetails = getDefaultMediaDetails()
       const newItem: MediaItem = {
         id: randomId(),
@@ -99,6 +110,7 @@ export function UploadMediaModal({ open, onOpenChange, onSubmit }: UploadMediaMo
         duration: probed.duration ?? mediaDetails.duration,
         width: probed.width ?? mediaDetails.width,
         height: probed.height ?? mediaDetails.height,
+        blobFetchable,
         createdAt: new Date().toISOString().split("T")[0],
       }
       await onSubmit(newItem)

--- a/apps/console/src/features/broadcast/use-youtube-oauth.ts
+++ b/apps/console/src/features/broadcast/use-youtube-oauth.ts
@@ -74,6 +74,7 @@ export function useYouTubeOAuth() {
             access_token: tokens.access_token,
             refresh_token: tokens.refresh_token,
             token_expires_at: new Date(Date.now() + tokens.expires_in * 1000).toISOString(),
+            status: "active",
             connected_by: user.id,
           },
           { onConflict: "workspace_id" },

--- a/apps/console/src/features/broadcast/youtube-connection-card.tsx
+++ b/apps/console/src/features/broadcast/youtube-connection-card.tsx
@@ -37,6 +37,7 @@ export function YouTubeConnectionCard() {
       description="Live streams"
       isLoading={isLoadingConnection}
       isConnected={Boolean(youtubeConnection)}
+      needsReauth={youtubeConnection?.status === "reauth_required"}
       accountLabel={youtubeConnection?.channelTitle ?? null}
       canManage={role?.can_manage_roles === true}
       onConnect={startOAuthFlow}

--- a/apps/console/src/features/broadcast/youtube-streams.tsx
+++ b/apps/console/src/features/broadcast/youtube-streams.tsx
@@ -15,6 +15,7 @@ import { StreamListItem } from "./stream-list-item"
 import { StreamModal, type StreamFormData } from "./stream-modal"
 import { StreamDetailDrawer } from "./stream-detail-drawer"
 import { createStream, updateStream, deleteStream, syncStreamsFromYouTube, saveStreamPreset } from "@/data/mutate-streams"
+import { uploadStreamThumbnail } from "@/data/mutate-broadcast"
 import { getErrorMessage } from "@moc/utils/get-error-message"
 import type { Stream } from "@moc/types/broadcast/stream"
 import { useNavigate } from "react-router-dom"
@@ -53,14 +54,24 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
 
   const handleCreate = useCallback(async (params: StreamFormData) => {
     try {
-      const newStream = await createStream(params)
+      const { stream: newStream, thumbnailError } = await createStream(params)
       syncStream(newStream)
       if (params.savePreset) {
+        // Persist a CORS-safe thumbnail reference: Upload-mode bytes are
+        // mirrored into our own Supabase bucket; URL/Media keep their
+        // already-validated source URL. Never the YouTube CDN URL.
+        let presetThumbnailUrl: string | null = null
+        if (params.thumbnail) {
+          presetThumbnailUrl =
+            params.thumbnail.origin === "file"
+              ? await uploadStreamThumbnail(params.thumbnail.blob).catch(() => null)
+              : params.thumbnail.sourceUrl
+        }
         saveStreamPreset({
           title: params.title,
           description: params.description,
           scheduledStartTime: params.scheduledStartTime,
-          thumbnailUrl: newStream.thumbnailUrl,
+          thumbnailUrl: presetThumbnailUrl,
           privacyStatus: params.privacyStatus,
           isForKids: params.isForKids,
           categoryId: params.categoryId,
@@ -73,7 +84,11 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
           playlistId: params.playlistId,
         }).catch(() => { /* non-fatal */ })
       }
-      toast({ title: "Stream created", variant: "success" })
+      if (thumbnailError) {
+        toast({ title: "Stream created, but the thumbnail wasn't applied", description: thumbnailError, variant: "warning" })
+      } else {
+        toast({ title: "Stream created", variant: "success" })
+      }
     } catch (error) {
       const message = getErrorMessage(error, "The stream could not be created.")
       toast({ title: "Failed to create stream", description: message, variant: "error" })
@@ -85,10 +100,14 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
     if (!editingStream) return
     try {
       const { thumbnail, ...fields } = params
-      const updated = await updateStream({ ...editingStream, ...fields }, thumbnail)
+      const { stream: updated, thumbnailError } = await updateStream({ ...editingStream, ...fields }, thumbnail)
       syncStream(updated)
       setEditingStream(null)
-      toast({ title: "Stream updated", variant: "success" })
+      if (thumbnailError) {
+        toast({ title: "Stream updated, but the thumbnail wasn't applied", description: thumbnailError, variant: "warning" })
+      } else {
+        toast({ title: "Stream updated", variant: "success" })
+      }
     } catch (error) {
       const message = getErrorMessage(error, "The stream could not be updated.")
       toast({ title: "Failed to update stream", description: message, variant: "error" })

--- a/apps/console/src/features/broadcast/youtube-streams.tsx
+++ b/apps/console/src/features/broadcast/youtube-streams.tsx
@@ -6,6 +6,7 @@ import { Drawer } from "@moc/ui/components/overlays/drawer"
 import { Decision } from "@moc/ui/components/display/decision"
 import { LoadingSpinner } from "@moc/ui/components/feedback/spinner"
 import { EmptyState } from "@moc/ui/components/feedback/empty-state"
+import { Alert } from "@moc/ui/components/feedback/alert"
 import { useFeedback } from "@moc/ui/components/feedback/feedback-provider"
 import { useAuth } from "@/lib/auth-context"
 import { useBroadcast } from "./broadcast-provider"
@@ -50,9 +51,21 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
   const [filterOpen, setFilterOpen] = useState(false)
 
   const isConnected = Boolean(youtubeConnection)
-  const canCreate = role?.can_create === true
+  const needsReauth = youtubeConnection?.status === "reauth_required"
+  const canCreate = role?.can_create === true && !needsReauth
+
+  const reauthGuard = useCallback(() => {
+    if (!needsReauth) return false
+    toast({
+      title: "YouTube disconnected",
+      description: "Reconnect YouTube in Settings to resume this action.",
+      variant: "error",
+    })
+    return true
+  }, [needsReauth, toast])
 
   const handleCreate = useCallback(async (params: StreamFormData) => {
+    if (reauthGuard()) return
     try {
       const { stream: newStream, thumbnailError } = await createStream(params)
       syncStream(newStream)
@@ -94,10 +107,11 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
       toast({ title: "Failed to create stream", description: message, variant: "error" })
       throw new Error(message)
     }
-  }, [syncStream, toast])
+  }, [syncStream, toast, reauthGuard])
 
   const handleUpdate = useCallback(async (params: StreamFormData) => {
     if (!editingStream) return
+    if (reauthGuard()) return
     try {
       const { thumbnail, ...fields } = params
       const { stream: updated, thumbnailError } = await updateStream({ ...editingStream, ...fields }, thumbnail)
@@ -113,9 +127,10 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
       toast({ title: "Failed to update stream", description: message, variant: "error" })
       throw new Error(message)
     }
-  }, [editingStream, syncStream, toast])
+  }, [editingStream, syncStream, toast, reauthGuard])
 
   const handleDelete = useCallback(async (stream: Stream) => {
+    if (reauthGuard()) return
     try {
       await deleteStream(stream)
       removeStream(stream.id)
@@ -124,9 +139,10 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
     } catch (error) {
       toast({ title: "Failed to delete stream", description: getErrorMessage(error, "The stream could not be deleted."), variant: "error" })
     }
-  }, [removeStream, toast])
+  }, [removeStream, toast, reauthGuard])
 
   const handleSync = useCallback(async () => {
+    if (reauthGuard()) return
     setIsSyncing(true)
     try {
       const synced = await syncStreamsFromYouTube()
@@ -137,7 +153,7 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
     } finally {
       setIsSyncing(false)
     }
-  }, [setStreams, toast])
+  }, [setStreams, toast, reauthGuard])
 
   function handleOpenCreate() {
     setEditingStream(null)
@@ -157,6 +173,14 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
 
   return (
     <>
+      {isConnected && needsReauth && (
+        <Alert
+          variant="error"
+          title="YouTube disconnected"
+          description="The YouTube authorization expired or was revoked. Reconnect to resume syncing, creating, and editing streams."
+          className="mb-1.5"
+        />
+      )}
       <Card>
         <Card.Header tight className="gap-1.5 justify-between">
           <div className="flex items-center gap-1.5">
@@ -166,7 +190,7 @@ export function YouTubeStreamsView({ searchQuery }: { searchQuery: string }) {
           {isConnected && (
             <div className="flex items-center gap-1">
               <Button.Icon variant="ghost" icon={<Settings2 />} onClick={() => setFilterOpen(true)} />
-              <Button.Icon variant="ghost" icon={<RefreshCw />} onClick={handleSync} disabled={isSyncing} />
+              <Button.Icon variant="ghost" icon={<RefreshCw />} onClick={handleSync} disabled={isSyncing || needsReauth} />
               {canCreate && (
                 <Button.Icon variant="secondary" icon={<Plus />} onClick={handleOpenCreate} />
               )}

--- a/apps/console/src/features/requests/unsaved-changes-modal.tsx
+++ b/apps/console/src/features/requests/unsaved-changes-modal.tsx
@@ -9,9 +9,13 @@ type UnsavedChangesModalProps = {
     onDiscard: () => void
     onCancel: () => void
     isSaving?: boolean
+    message?: string
 }
 
-export function UnsavedChangesModal({ open, onSave, onDiscard, onCancel, isSaving = false }: UnsavedChangesModalProps) {
+const DEFAULT_MESSAGE =
+    'You are about to close this request with unsaved changes. Would you like to save these changes before closing?'
+
+export function UnsavedChangesModal({ open, onSave, onDiscard, onCancel, isSaving = false, message = DEFAULT_MESSAGE }: UnsavedChangesModalProps) {
     return (
         <Modal open={open} onOpenChange={(o) => { if (!o) onCancel() }}>
             <Modal.Portal>
@@ -24,7 +28,7 @@ export function UnsavedChangesModal({ open, onSave, onDiscard, onCancel, isSavin
                         <Modal.Content className="p-4 flex-row gap-4">
                             <TriangleAlert className='size-8 shrink-0' />
                             <Paragraph.sm className="text-secondary">
-                                You are about to close this request with unsaved changes. Would you like to save these changes before closing?
+                                {message}
                             </Paragraph.sm>
                         </Modal.Content>
                         <Modal.Footer className="justify-end">

--- a/apps/console/src/lib/youtube-api.ts
+++ b/apps/console/src/lib/youtube-api.ts
@@ -38,15 +38,6 @@ export async function uploadThumbnail(videoId: string, file: Blob): Promise<void
   }
 }
 
-export async function uploadThumbnailFromUrl(videoId: string, imageUrl: string): Promise<void> {
-  const imageResponse = await fetch(imageUrl)
-  if (!imageResponse.ok) {
-    throw new Error(`Failed to fetch thumbnail image from URL`)
-  }
-  const blob = await imageResponse.blob()
-  await uploadThumbnail(videoId, blob)
-}
-
 export async function fetchVideoCategories(regionCode = "US") {
   const response = await youtubeApiFetch(
     `/videoCategories?part=snippet&regionCode=${regionCode}`,

--- a/apps/console/src/lib/youtube-auth.ts
+++ b/apps/console/src/lib/youtube-auth.ts
@@ -9,6 +9,19 @@ type ConnectionTokens = {
   token_expires_at: string
 }
 
+/**
+ * The stored refresh token is permanently dead (Google returned
+ * invalid_grant). The connection row has been flagged reauth_required;
+ * the user must reconnect YouTube. Distinct from transient refresh
+ * failures so the UI can prompt a reconnect rather than a generic retry.
+ */
+export class YouTubeReauthRequiredError extends Error {
+  constructor(message = "YouTube disconnected — reconnect to resume YouTube operations") {
+    super(message)
+    this.name = "YouTubeReauthRequiredError"
+  }
+}
+
 async function getJsonError(response: Response, fallback: string): Promise<string> {
   const contentType = response.headers.get("content-type") ?? ""
   if (contentType.includes("application/json")) {
@@ -50,6 +63,20 @@ export async function getValidAccessToken(): Promise<string> {
   })
 
   if (!response.ok) {
+    if (response.status === 401) {
+      const body = await response.json().catch(() => ({})) as { error?: string; code?: string }
+      if (body.code === "reauth_required") {
+        // Refresh token is dead. Persist the health flag (best-effort:
+        // blocked silently for can_read-only members, which is fine —
+        // the throw below still prevents the operation) so the UI can
+        // surface the reconnect banner and disable YouTube actions.
+        await supabase
+          .from("youtube_connections")
+          .update({ status: "reauth_required" })
+          .eq("id", connection.id)
+        throw new YouTubeReauthRequiredError(body.error)
+      }
+    }
     throw new Error(await getJsonError(response, "YouTube token refresh failed"))
   }
 

--- a/apps/console/src/lib/youtube-client.ts
+++ b/apps/console/src/lib/youtube-client.ts
@@ -5,7 +5,6 @@ export { exchangeCodeForTokens, revokeToken } from "./youtube-auth"
 export {
   youtubeApiFetch,
   uploadThumbnail,
-  uploadThumbnailFromUrl,
   fetchVideoCategories,
   fetchChannelPlaylists,
   addVideoToPlaylist,

--- a/apps/console/src/screens/account/settings/message-templates/detail/page.tsx
+++ b/apps/console/src/screens/account/settings/message-templates/detail/page.tsx
@@ -1,0 +1,300 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Navigate, useBlocker, useNavigate, useParams } from "react-router-dom";
+import { Header } from "@moc/ui/components/display/header";
+import { Title, Label, Paragraph } from "@moc/ui/components/display/text";
+import { Card } from "@moc/ui/components/display/card";
+import { Divider } from "@moc/ui/components/display/divider";
+import { TextArea } from "@moc/ui/components/form/text-area";
+import { Button } from "@moc/ui/components/controls/button";
+import { SegmentedControl } from "@moc/ui/components/controls/segmented-control";
+import { Spinner } from "@moc/ui/components/feedback/spinner";
+import { useFeedback } from "@moc/ui/components/feedback/feedback-provider";
+import { ArrowLeft } from "lucide-react";
+import { useAuth } from "@/lib/auth-context";
+import { useWorkspace } from "@/lib/workspace-context";
+import { routes } from "@/screens/console-routes";
+import {
+    DEFAULT_TEMPLATES,
+    SAMPLE_TOKENS,
+    TEMPLATE_TOKENS,
+    renderTemplate,
+    validateTemplate,
+    type MessageType,
+} from "@/data/notification-templates-core";
+import {
+    deleteNotificationTemplate,
+    fetchNotificationTemplates,
+    upsertNotificationTemplate,
+} from "@/data/notification-templates";
+import { UnsavedChangesModal } from "@/features/requests/unsaved-changes-modal";
+import { isMessageType, messageTypeMeta } from "../meta";
+import { PreviewText } from "../preview-text";
+
+const SETTINGS_TELEGRAM = `/${routes.settings}?tab=telegram`;
+
+export function MessageTemplateDetailScreen() {
+    const { messageType: raw } = useParams<{ messageType: string }>();
+    const { role } = useAuth();
+    const canManage = role?.can_manage_roles === true;
+
+    if (!raw || !isMessageType(raw) || !canManage) {
+        return <Navigate to={SETTINGS_TELEGRAM} replace />;
+    }
+    return <Editor messageType={raw} />;
+}
+
+function Editor({ messageType }: { messageType: MessageType }) {
+    const navigate = useNavigate();
+    const { toast } = useFeedback();
+    const { currentWorkspaceId } = useWorkspace();
+    const meta = messageTypeMeta(messageType);
+    const defaultBody = DEFAULT_TEMPLATES[messageType];
+
+    const [isLoading, setIsLoading] = useState(true);
+    const [hasCustom, setHasCustom] = useState(false);
+    const [savedBody, setSavedBody] = useState<string | null>(null); // null = on default
+    const [body, setBody] = useState(defaultBody);
+    const [view, setView] = useState<"source" | "preview">("source");
+    const [saving, setSaving] = useState(false);
+    const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+    useEffect(() => {
+        if (!currentWorkspaceId) return;
+        let cancelled = false;
+        setIsLoading(true);
+        void (async () => {
+            try {
+                const rows = await fetchNotificationTemplates(currentWorkspaceId);
+                if (cancelled) return;
+                const row = rows.find((r) => r.messageType === messageType);
+                setHasCustom(!!row);
+                setSavedBody(row ? row.body : null);
+                setBody(row ? row.body : defaultBody);
+            } catch (error) {
+                if (!cancelled) {
+                    toast({
+                        title: "Couldn't load template",
+                        description: error instanceof Error ? error.message : "Unknown error",
+                        variant: "error",
+                    });
+                }
+            } finally {
+                if (!cancelled) setIsLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [currentWorkspaceId, messageType, defaultBody, toast]);
+
+    const unknown = useMemo(() => validateTemplate(messageType, body), [messageType, body]);
+    const preview = useMemo(
+        () => renderTemplate(body, SAMPLE_TOKENS[messageType]),
+        [messageType, body],
+    );
+
+    const dirty = body !== (savedBody ?? defaultBody);
+    const canSave = dirty && unknown.length === 0 && body.trim() !== "" && !saving;
+
+    // Block in-app navigation (incl. the back button) while dirty.
+    const blocker = useBlocker(dirty);
+
+    // Guard browser refresh / tab close while dirty.
+    useEffect(() => {
+        if (!dirty) return;
+        function onBeforeUnload(e: BeforeUnloadEvent) {
+            e.preventDefault();
+        }
+        window.addEventListener("beforeunload", onBeforeUnload);
+        return () => window.removeEventListener("beforeunload", onBeforeUnload);
+    }, [dirty]);
+
+    const insertToken = useCallback(
+        (name: string) => {
+            const el = textareaRef.current;
+            const token = `{{${name}}}`;
+            if (!el) {
+                setBody((b) => b + token);
+                return;
+            }
+            const start = el.selectionStart ?? body.length;
+            const end = el.selectionEnd ?? body.length;
+            setBody(body.slice(0, start) + token + body.slice(end));
+            requestAnimationFrame(() => {
+                el.focus();
+                const caret = start + token.length;
+                el.setSelectionRange(caret, caret);
+            });
+        },
+        [body],
+    );
+
+    const handleSave = useCallback(async (): Promise<boolean> => {
+        if (!currentWorkspaceId) return false;
+        setSaving(true);
+        try {
+            await upsertNotificationTemplate({
+                workspaceId: currentWorkspaceId,
+                scope: meta.scope,
+                messageType,
+                body,
+            });
+            setSavedBody(body);
+            setHasCustom(true);
+            toast({ title: "Template saved", variant: "success" });
+            return true;
+        } catch (error) {
+            toast({
+                title: "Couldn't save template",
+                description: error instanceof Error ? error.message : "Unknown error",
+                variant: "error",
+            });
+            return false;
+        } finally {
+            setSaving(false);
+        }
+    }, [currentWorkspaceId, meta.scope, messageType, body, toast]);
+
+    const handleBlockerSave = useCallback(async () => {
+        const ok = await handleSave();
+        if (ok && blocker.state === "blocked") blocker.proceed();
+    }, [handleSave, blocker]);
+
+    const handleBlockerDiscard = useCallback(() => {
+        setBody(savedBody ?? defaultBody);
+        if (blocker.state === "blocked") blocker.proceed();
+    }, [blocker, savedBody, defaultBody]);
+
+    const handleBlockerCancel = useCallback(() => {
+        if (blocker.state === "blocked") blocker.reset();
+    }, [blocker]);
+
+    const handleRestore = useCallback(async () => {
+        if (!currentWorkspaceId) return;
+        setSaving(true);
+        try {
+            await deleteNotificationTemplate({
+                workspaceId: currentWorkspaceId,
+                scope: meta.scope,
+                messageType,
+            });
+            setSavedBody(null);
+            setHasCustom(false);
+            setBody(defaultBody);
+            toast({ title: "Default restored", variant: "success" });
+        } catch (error) {
+            toast({
+                title: "Couldn't restore default",
+                description: error instanceof Error ? error.message : "Unknown error",
+                variant: "error",
+            });
+        } finally {
+            setSaving(false);
+        }
+    }, [currentWorkspaceId, meta.scope, messageType, defaultBody, toast]);
+
+    return (
+        <section className="mx-auto max-w-content-md">
+            <Header className="p-4 pt-8">
+                <Header.Lead className="gap-1">
+                    <button
+                        type="button"
+                        onClick={() => navigate(SETTINGS_TELEGRAM)}
+                        className="flex items-center gap-1 text-tertiary hover:text-primary"
+                    >
+                        <ArrowLeft className="size-4" />
+                        <Label.xs className="text-inherit">Message templates</Label.xs>
+                    </button>
+                    <Title.h6 className="pt-2">{meta.label}</Title.h6>
+                    <Paragraph.xs className="text-tertiary pt-1">{meta.description}</Paragraph.xs>
+                </Header.Lead>
+            </Header>
+
+            <div className="p-4">
+                {isLoading ? (
+                    <div className="flex justify-center py-16">
+                        <Spinner size="lg" />
+                    </div>
+                ) : (
+                    <Card>
+                        <Card.Header tight>
+                            <div className="flex flex-1 flex-col gap-0.5">
+                                <Label.sm>Body</Label.sm>
+                                <Paragraph.xs className="text-quaternary">
+                                    {hasCustom ? "Custom template" : "Using built-in default"}
+                                </Paragraph.xs>
+                            </div>
+                            <SegmentedControl
+                                value={view}
+                                onValueChange={(v) => setView(v as "source" | "preview")}
+                            >
+                                <SegmentedControl.Item value="source">Source</SegmentedControl.Item>
+                                <SegmentedControl.Item value="preview">Preview</SegmentedControl.Item>
+                            </SegmentedControl>
+                        </Card.Header>
+                        <Card.Content className="flex flex-col gap-3 p-3">
+                            {view === "source" ? (
+                                <>
+                                    <TextArea
+                                        ref={textareaRef}
+                                        value={body}
+                                        onChange={(e) => setBody(e.target.value)}
+                                        resize="vertical"
+                                        rows={14}
+                                        className="font-mono"
+                                    />
+                                    <div className="flex flex-wrap gap-1.5">
+                                        {TEMPLATE_TOKENS[messageType].map((t) => (
+                                            <button
+                                                key={t.name}
+                                                type="button"
+                                                onClick={() => insertToken(t.name)}
+                                                className="rounded bg-utility-gray-50 px-1.5 py-0.5 font-mono text-utility-gray-700 hover:bg-utility-gray-100"
+                                            >
+                                                <Label.xs className="text-inherit">{`{{ ${t.name} }}`}</Label.xs>
+                                            </button>
+                                        ))}
+                                    </div>
+                                    {unknown.length > 0 && (
+                                        <Paragraph.xs className="text-utility-red-700">
+                                            Unknown placeholder{unknown.length > 1 ? "s" : ""} for this
+                                            message: {unknown.map((u) => `{{${u}}}`).join(", ")}
+                                        </Paragraph.xs>
+                                    )}
+                                </>
+                            ) : (
+                                <div className="rounded-lg border border-tertiary bg-secondary p-3">
+                                    <PreviewText text={preview} />
+                                </div>
+                            )}
+
+                            <Divider />
+
+                            <div className="flex items-center justify-end gap-2">
+                                <Button
+                                    variant="secondary"
+                                    disabled={saving || !hasCustom}
+                                    onClick={handleRestore}
+                                >
+                                    Restore default
+                                </Button>
+                                <Button variant="primary" disabled={!canSave} onClick={handleSave}>
+                                    Save changes
+                                </Button>
+                            </div>
+                        </Card.Content>
+                    </Card>
+                )}
+            </div>
+
+            <UnsavedChangesModal
+                open={blocker.state === "blocked"}
+                onSave={handleBlockerSave}
+                onDiscard={handleBlockerDiscard}
+                onCancel={handleBlockerCancel}
+                isSaving={saving}
+                message="You have unsaved changes to this template. Save them before leaving, or discard to continue."
+            />
+        </section>
+    );
+}

--- a/apps/console/src/screens/account/settings/message-templates/list.tsx
+++ b/apps/console/src/screens/account/settings/message-templates/list.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Section } from "@moc/ui/components/display/section";
+import { Divider } from "@moc/ui/components/display/divider";
+import { Paragraph, Label } from "@moc/ui/components/display/text";
+import { Badge } from "@moc/ui/components/display/badge";
+import { LoadingSpinner } from "@moc/ui/components/feedback/spinner";
+import { useFeedback } from "@moc/ui/components/feedback/feedback-provider";
+import { ChevronRight } from "lucide-react";
+import { useWorkspace } from "@/lib/workspace-context";
+import { routes } from "@/screens/console-routes";
+import type { MessageType } from "@/data/notification-templates-core";
+import { fetchNotificationTemplates } from "@/data/notification-templates";
+import { GROUP_MESSAGE_TYPES, DM_MESSAGE_TYPES, messageTypeMeta } from "./meta";
+
+function detailPath(type: MessageType): string {
+    return `/${routes.messageTemplateDetail.replace(":messageType", encodeURIComponent(type))}`;
+}
+
+function TemplateRow({
+    type,
+    customised,
+    onOpen,
+}: {
+    type: MessageType;
+    customised: boolean;
+    onOpen: () => void;
+}) {
+    const meta = messageTypeMeta(type);
+    return (
+        <button
+            type="button"
+            onClick={onOpen}
+            className="flex w-full items-center justify-between gap-3 px-3 py-3 text-left border-b border-tertiary last:border-b-0 hover:bg-secondary"
+        >
+            <div className="flex flex-1 flex-col gap-0.5">
+                <div className="flex items-center gap-2">
+                    <Label.sm>{meta.label}</Label.sm>
+                    {customised && <Badge label="Customised" color="blue" variant="outline" />}
+                </div>
+                <Paragraph.xs className="text-quaternary">{meta.description}</Paragraph.xs>
+            </div>
+            <ChevronRight className="size-4 shrink-0 text-quaternary" />
+        </button>
+    );
+}
+
+export function MessageTemplates() {
+    const { toast } = useFeedback();
+    const navigate = useNavigate();
+    const { currentWorkspaceId } = useWorkspace();
+    const [isLoading, setIsLoading] = useState(true);
+    const [customised, setCustomised] = useState<Set<MessageType>>(new Set());
+
+    useEffect(() => {
+        if (!currentWorkspaceId) {
+            setIsLoading(false);
+            return;
+        }
+        let cancelled = false;
+        setIsLoading(true);
+        void (async () => {
+            try {
+                const rows = await fetchNotificationTemplates(currentWorkspaceId);
+                if (!cancelled) setCustomised(new Set(rows.map((r) => r.messageType)));
+            } catch (error) {
+                if (!cancelled) {
+                    toast({
+                        title: "Couldn't load message templates",
+                        description: error instanceof Error ? error.message : "Unknown error",
+                        variant: "error",
+                    });
+                }
+            } finally {
+                if (!cancelled) setIsLoading(false);
+            }
+        })();
+        return () => {
+            cancelled = true;
+        };
+    }, [currentWorkspaceId, toast]);
+
+    if (!currentWorkspaceId) return null;
+
+    return (
+        <Section>
+            <Section.Header
+                title="Message templates"
+                description="Customise the text of Telegram notifications. Click a message to edit its template; leave it untouched to keep the built-in wording."
+            />
+            <Divider className="py-6" />
+            {isLoading ? (
+                <div className="flex justify-center py-6">
+                    <LoadingSpinner size="lg" />
+                </div>
+            ) : (
+                <Section.Body className="gap-6">
+                    <div className="flex flex-col">
+                        <Label.sm className="px-3 pb-2 text-tertiary">Group &amp; topic events</Label.sm>
+                        {GROUP_MESSAGE_TYPES.map((type) => (
+                            <TemplateRow
+                                key={type}
+                                type={type}
+                                customised={customised.has(type)}
+                                onOpen={() => navigate(detailPath(type))}
+                            />
+                        ))}
+                    </div>
+                    <div className="flex flex-col">
+                        <Label.sm className="px-3 pb-2 text-tertiary">
+                            Direct messages (assignments)
+                        </Label.sm>
+                        {DM_MESSAGE_TYPES.map((type) => (
+                            <TemplateRow
+                                key={type}
+                                type={type}
+                                customised={customised.has(type)}
+                                onOpen={() => navigate(detailPath(type))}
+                            />
+                        ))}
+                    </div>
+                </Section.Body>
+            )}
+        </Section>
+    );
+}

--- a/apps/console/src/screens/account/settings/message-templates/meta.ts
+++ b/apps/console/src/screens/account/settings/message-templates/meta.ts
@@ -1,0 +1,48 @@
+// Label + description + scope for every editable message type, shared
+// by the list and the detail page so the two never drift.
+
+import { NOTIFICATION_EVENTS } from "@/data/notification-events";
+import {
+    DM_MESSAGE_LABELS,
+    DM_MESSAGE_TYPES,
+    scopeForMessageType,
+    type DmMessageType,
+    type MessageType,
+    type TemplateScope,
+} from "@/data/notification-templates-core";
+
+const GROUP_META = new Map(
+    NOTIFICATION_EVENTS.map((e) => [e.key as MessageType, { label: e.label, description: e.description }]),
+);
+
+const DM_DESCRIPTIONS: Record<DmMessageType, string> = {
+    "assignment.request": "Direct message sent when someone is assigned to a request.",
+    "assignment.cue": "Direct message sent when someone is assigned to a cue.",
+    "assignment.checklist_item": "Direct message sent when someone is assigned to a checklist item.",
+};
+
+export type MessageTypeMeta = {
+    label: string;
+    description: string;
+    scope: TemplateScope;
+};
+
+export function messageTypeMeta(type: MessageType): MessageTypeMeta {
+    const scope = scopeForMessageType(type);
+    if (scope === "dm") {
+        return {
+            label: DM_MESSAGE_LABELS[type as DmMessageType],
+            description: DM_DESCRIPTIONS[type as DmMessageType],
+            scope,
+        };
+    }
+    const g = GROUP_META.get(type);
+    return { label: g?.label ?? type, description: g?.description ?? "", scope };
+}
+
+export function isMessageType(value: string): value is MessageType {
+    return GROUP_META.has(value as MessageType) || (DM_MESSAGE_TYPES as readonly string[]).includes(value);
+}
+
+export { DM_MESSAGE_TYPES };
+export const GROUP_MESSAGE_TYPES = NOTIFICATION_EVENTS.map((e) => e.key);

--- a/apps/console/src/screens/account/settings/message-templates/preview-text.tsx
+++ b/apps/console/src/screens/account/settings/message-templates/preview-text.tsx
@@ -1,0 +1,31 @@
+// Minimal allowlist renderer for the live preview: only <b>, <i> and
+// <a href="..."> become real nodes; everything else stays literal text.
+// Never dangerouslySetInnerHTML raw admin input.
+
+export function PreviewText({ text }: { text: string }) {
+    const re = /<b>(.*?)<\/b>|<i>(.*?)<\/i>|<a href="(.*?)">(.*?)<\/a>/gs;
+    const nodes: React.ReactNode[] = [];
+    let last = 0;
+    let m: RegExpExecArray | null;
+    let k = 0;
+    while ((m = re.exec(text)) !== null) {
+        if (m.index > last) nodes.push(text.slice(last, m.index));
+        if (m[1] !== undefined) nodes.push(<b key={k++}>{m[1]}</b>);
+        else if (m[2] !== undefined) nodes.push(<i key={k++}>{m[2]}</i>);
+        else
+            nodes.push(
+                <a
+                    key={k++}
+                    href={m[3]}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-brand underline"
+                >
+                    {m[4]}
+                </a>,
+            );
+        last = re.lastIndex;
+    }
+    if (last < text.length) nodes.push(text.slice(last));
+    return <div className="whitespace-pre-wrap paragraph-sm">{nodes}</div>;
+}

--- a/apps/console/src/screens/account/settings/telegram-tab.tsx
+++ b/apps/console/src/screens/account/settings/telegram-tab.tsx
@@ -18,6 +18,7 @@ import { Decision } from "@moc/ui/components/display/decision";
 import { Toggle } from "@moc/ui/components/form/toggle";
 import { Button } from "@moc/ui/components/controls/button";
 import { ConnectEventsModal, type ConnectEventsTarget } from "./connect-events-modal";
+import { MessageTemplates } from "./message-templates/list";
 
 export function TelegramTab() {
     const { toast } = useFeedback();
@@ -166,6 +167,10 @@ export function TelegramTab() {
                     </Decision>
                 </Section.Body>
             </Section>
+
+            <Divider className="py-6" />
+
+            <MessageTemplates />
 
             <ConnectEventsModal target={connectTarget} onClose={() => setConnectTarget(null)} />
         </>

--- a/apps/console/src/screens/broadcast/streams/stream-detail/page.tsx
+++ b/apps/console/src/screens/broadcast/streams/stream-detail/page.tsx
@@ -80,10 +80,14 @@ export function StreamDetailScreen() {
       if (!stream) return
       try {
         const { thumbnail, ...fields } = params
-        const updated = await updateStream({ ...stream, ...fields }, thumbnail)
+        const { stream: updated, thumbnailError } = await updateStream({ ...stream, ...fields }, thumbnail)
         syncStream(updated)
         setStream(updated)
-        toast({ title: "Stream updated", variant: "success" })
+        if (thumbnailError) {
+          toast({ title: "Stream updated, but the thumbnail wasn't applied", description: thumbnailError, variant: "warning" })
+        } else {
+          toast({ title: "Stream updated", variant: "success" })
+        }
       } catch (error) {
         const message = getErrorMessage(error, "The stream could not be updated.")
         toast({ title: "Failed to update stream", description: message, variant: "error" })

--- a/apps/console/src/screens/console-routes.ts
+++ b/apps/console/src/screens/console-routes.ts
@@ -28,6 +28,7 @@ export const routes = {
     cueSheetChecklistDetail: 'cue-sheet/checklist/:id',
     cueSheetTemplates: 'cue-sheet/templates',
     settings: 'account/settings',
+    messageTemplateDetail: 'account/settings/message-templates/:messageType',
     privacy: 'legal/privacy',
     terms: 'legal/terms',
     support: 'support',

--- a/apps/console/tsconfig.app.json
+++ b/apps/console/tsconfig.app.json
@@ -30,5 +30,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx"]
 }

--- a/apps/request/api/notify/booking.ts
+++ b/apps/request/api/notify/booking.ts
@@ -70,6 +70,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
   const payload: Record<string, unknown> = {
     event_type,
     workspace_id,
+    tracking_code,
     title,
     link_url: linkUrl,
     requester_name: typeof body.requester_name === "string" ? body.requester_name : null,

--- a/apps/request/api/notify/request.ts
+++ b/apps/request/api/notify/request.ts
@@ -69,6 +69,7 @@ export default async function handler(request: ApiRequest, response: ApiResponse
   const payload: Record<string, unknown> = {
     event_type,
     workspace_id,
+    request_id,
     title,
     link_url: linkUrl,
     requester_name: typeof body.requester_name === "string" ? body.requester_name : null,

--- a/docs/phases/patches/2026-05-17-media-blob-fetchable.sql
+++ b/docs/phases/patches/2026-05-17-media-blob-fetchable.sql
@@ -1,0 +1,23 @@
+-- ============================================================
+-- patch 2026-05-17 — media blob fetchability
+-- ============================================================
+-- Adds blob_fetchable: whether the media item's URL can be read as
+-- a binary blob from the browser (i.e. it is same-origin or sends
+-- CORS headers), determined client-side at add time for IMAGE media
+-- via a stream-first-chunk-then-abort probe.
+--
+--   TRUE  — bytes are reachable; safe to re-upload as a YouTube
+--           stream thumbnail.
+--   FALSE — fetch/CORS-blocked; hidden from the thumbnail picker.
+--   NULL  — not applicable (audio/video) or not yet probed (legacy
+--           rows). Legacy NULL image rows stay selectable; the
+--           stream modal re-validates on selection, so a stale one
+--           surfaces a clear error instead of failing silently.
+--
+-- Idempotent: safe to run repeatedly on a live database. Also folded
+-- into the canonical phase-01-schema.sql for fresh installs; this
+-- patch is ONLY for already-provisioned databases.
+-- ============================================================
+
+ALTER TABLE public.media
+  ADD COLUMN IF NOT EXISTS blob_fetchable boolean NULL;

--- a/docs/phases/patches/2026-05-17-notification-message-templates.sql
+++ b/docs/phases/patches/2026-05-17-notification-message-templates.sql
@@ -1,0 +1,59 @@
+-- ============================================================
+-- patch 2026-05-17 — customizable Telegram notification templates
+-- ============================================================
+-- Adds notification_message_templates: per-workspace custom text for
+-- Telegram notifications. One row per (workspace, scope, message_type).
+--
+--   scope        — 'group' (event routing) | 'dm' (assignment DMs)
+--   message_type — NotificationEventKey for group scope, or
+--                   'assignment.request' | 'assignment.cue' |
+--                   'assignment.checklist_item' for dm scope
+--   body         — the raw template string with {{token}} placeholders
+--
+-- Absence of a row means "use the hardcoded default", so existing
+-- workspaces deliver unchanged messages. "Restore default" in the UI
+-- deletes the row.
+--
+-- Idempotent: safe to run repeatedly on a live database. Also folded
+-- into the canonical phase-01-schema.sql / phase-03-security.sql for
+-- fresh installs; this patch is ONLY for already-provisioned databases.
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.notification_message_templates (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid        NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  scope        text        NOT NULL,
+  message_type text        NOT NULL,
+  body         text        NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS notification_message_templates_unique
+  ON public.notification_message_templates (workspace_id, scope, message_type);
+
+ALTER TABLE public.notification_message_templates ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "notification_message_templates_select" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_select" ON public.notification_message_templates
+  FOR SELECT TO authenticated
+  USING (
+    private.is_workspace_member(workspace_id)
+    OR private.current_user_can('can_manage_roles')
+  );
+
+DROP POLICY IF EXISTS "notification_message_templates_insert" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_insert" ON public.notification_message_templates
+  FOR INSERT TO authenticated
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "notification_message_templates_update" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_update" ON public.notification_message_templates
+  FOR UPDATE TO authenticated
+  USING (private.current_user_can('can_manage_roles'))
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "notification_message_templates_delete" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_delete" ON public.notification_message_templates
+  FOR DELETE TO authenticated
+  USING (private.current_user_can('can_manage_roles'));

--- a/docs/phases/patches/2026-05-18-youtube-connection-status.sql
+++ b/docs/phases/patches/2026-05-18-youtube-connection-status.sql
@@ -1,0 +1,28 @@
+-- ============================================================
+-- patch 2026-05-18 — youtube connection health status
+-- ============================================================
+-- Adds youtube_connections.status: whether the stored OAuth
+-- refresh token is still usable.
+--
+--   'active'          — refresh token works; YouTube ops allowed.
+--   'reauth_required' — Google returned invalid_grant on token
+--                       refresh (refresh token expired or revoked).
+--                       Set client-side when /api/youtube/oauth/refresh
+--                       reports reauth_required; cleared on reconnect.
+--
+-- Why a column and not a timer: Google does not expose a refresh
+-- token expiry (no refresh_token_expires_in), so refresh-token
+-- death is only detectable reactively, on a failed refresh.
+--
+-- Idempotent: safe to run repeatedly on a live database. Also
+-- folded into the canonical phase-01-schema.sql for fresh installs;
+-- this patch is ONLY for already-provisioned databases.
+-- ============================================================
+
+DO $$ BEGIN
+  CREATE TYPE public.youtube_connection_status AS ENUM ('active', 'reauth_required');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE public.youtube_connections
+  ADD COLUMN IF NOT EXISTS status public.youtube_connection_status NOT NULL DEFAULT 'active';

--- a/docs/phases/phase-01-schema.sql
+++ b/docs/phases/phase-01-schema.sql
@@ -227,6 +227,7 @@ CREATE TABLE IF NOT EXISTS public.media (
   duration_seconds numeric           NULL,
   width            integer           NULL,
   height           integer           NULL,
+  blob_fetchable   boolean           NULL,
   created_at       timestamptz       NOT NULL DEFAULT now()
 );
 

--- a/docs/phases/phase-01-schema.sql
+++ b/docs/phases/phase-01-schema.sql
@@ -78,6 +78,11 @@ EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
 
 DO $$ BEGIN
+  CREATE TYPE public.youtube_connection_status AS ENUM ('active', 'reauth_required');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
   CREATE TYPE public.zoom_meeting_type AS ENUM ('instant', 'scheduled', 'recurring_no_fixed', 'recurring_fixed');
 EXCEPTION WHEN duplicate_object THEN NULL;
 END $$;
@@ -424,7 +429,8 @@ CREATE TABLE IF NOT EXISTS public.checklist_item_assignees (
   UNIQUE (checklist_item_id, user_id, duty)
 );
 
--- youtube_connections (phase-13; token_expires_at NOT NULL folded from phase-16)
+-- youtube_connections (phase-13; token_expires_at NOT NULL folded from phase-16;
+-- status folded from patch 2026-05-18)
 CREATE TABLE IF NOT EXISTS public.youtube_connections (
   id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
   workspace_id     uuid        NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
@@ -434,6 +440,7 @@ CREATE TABLE IF NOT EXISTS public.youtube_connections (
   access_token     text        NOT NULL,
   refresh_token    text        NOT NULL,
   token_expires_at timestamptz NOT NULL,
+  status           public.youtube_connection_status NOT NULL DEFAULT 'active',
   connected_by     uuid        NOT NULL REFERENCES public.users(id),
   created_at       timestamptz NOT NULL DEFAULT now(),
   updated_at       timestamptz NOT NULL DEFAULT now(),

--- a/docs/phases/phase-01-schema.sql
+++ b/docs/phases/phase-01-schema.sql
@@ -604,6 +604,24 @@ CREATE TABLE IF NOT EXISTS public.notification_routes (
   updated_at    timestamptz NOT NULL DEFAULT now()
 );
 
+-- notification_message_templates (phase-29)
+-- Per-workspace custom text for Telegram notifications. One row per
+-- (workspace, scope, message_type); absence of a row means "use the
+-- hardcoded default", so existing workspaces are unaffected.
+--   scope        — 'group' (event routing) | 'dm' (assignment DMs)
+--   message_type — NotificationEventKey for group scope, or
+--                   'assignment.request' | 'assignment.cue' |
+--                   'assignment.checklist_item' for dm scope
+CREATE TABLE IF NOT EXISTS public.notification_message_templates (
+  id           uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid        NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  scope        text        NOT NULL,
+  message_type text        NOT NULL,
+  body         text        NOT NULL,
+  created_at   timestamptz NOT NULL DEFAULT now(),
+  updated_at   timestamptz NOT NULL DEFAULT now()
+);
+
 -- ===== INDEXES =====
 
 -- workspace_users
@@ -733,6 +751,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS notification_routes_unique_no_topic
   WHERE thread_id IS NULL;
 CREATE INDEX IF NOT EXISTS notification_routes_lookup_idx
   ON public.notification_routes (workspace_id, event_type) WHERE enabled = true;
+
+-- notification_message_templates (phase-29)
+CREATE UNIQUE INDEX IF NOT EXISTS notification_message_templates_unique
+  ON public.notification_message_templates (workspace_id, scope, message_type);
 
 -- ===== SEED (the ONLY data; safe to skip/replace for a custom setup) =====
 

--- a/docs/phases/phase-03-security.sql
+++ b/docs/phases/phase-03-security.sql
@@ -51,6 +51,7 @@ ALTER TABLE public.telegram_link_tokens ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.telegram_groups ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.telegram_group_topics ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.notification_routes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.notification_message_templates ENABLE ROW LEVEL SECURITY;
 
 -- ===== IDENTITY TABLE POLICIES (phase-09) =====
 
@@ -1666,6 +1667,32 @@ CREATE POLICY "notification_routes_update" ON public.notification_routes
 
 DROP POLICY IF EXISTS "notification_routes_delete" ON public.notification_routes;
 CREATE POLICY "notification_routes_delete" ON public.notification_routes
+  FOR DELETE TO authenticated
+  USING (private.current_user_can('can_manage_roles'));
+
+-- notification_message_templates (phase-29) — mirrors notification_routes:
+-- workspace members can read; only role managers can write.
+DROP POLICY IF EXISTS "notification_message_templates_select" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_select" ON public.notification_message_templates
+  FOR SELECT TO authenticated
+  USING (
+    private.is_workspace_member(workspace_id)
+    OR private.current_user_can('can_manage_roles')
+  );
+
+DROP POLICY IF EXISTS "notification_message_templates_insert" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_insert" ON public.notification_message_templates
+  FOR INSERT TO authenticated
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "notification_message_templates_update" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_update" ON public.notification_message_templates
+  FOR UPDATE TO authenticated
+  USING (private.current_user_can('can_manage_roles'))
+  WITH CHECK (private.current_user_can('can_manage_roles'));
+
+DROP POLICY IF EXISTS "notification_message_templates_delete" ON public.notification_message_templates;
+CREATE POLICY "notification_message_templates_delete" ON public.notification_message_templates
   FOR DELETE TO authenticated
   USING (private.current_user_can('can_manage_roles'));
 

--- a/packages/types/src/broadcast/media-item.ts
+++ b/packages/types/src/broadcast/media-item.ts
@@ -9,5 +9,10 @@ export type MediaItem = {
   duration: number | null // intrinsic source seconds; null for images or when not yet probed
   width: number | null // intrinsic pixel width; null for audio or when not yet probed
   height: number | null // intrinsic pixel height; null for audio or when not yet probed
+  // Whether the URL's bytes are reachable from the browser (same-origin or
+  // CORS-enabled). Set at add time for images only. true = usable as a stream
+  // thumbnail; false = hidden from the thumbnail picker; null = not applicable
+  // (audio/video) or legacy row not yet probed.
+  blobFetchable: boolean | null
   createdAt: string
 }

--- a/packages/types/src/broadcast/stream.ts
+++ b/packages/types/src/broadcast/stream.ts
@@ -53,6 +53,11 @@ export type StreamPreset = {
   playlistId: string | null
 }
 
+// 'active'          — stored refresh token works; YouTube ops allowed.
+// 'reauth_required' — Google returned invalid_grant on token refresh;
+//                     the user must reconnect YouTube. Cleared on reconnect.
+export type YouTubeConnectionStatus = "active" | "reauth_required"
+
 export type YouTubeConnection = {
   id: string
   workspaceId: string
@@ -61,6 +66,7 @@ export type YouTubeConnection = {
   connectedBy: string
   createdAt: string
   tokenExpiresAt: string
+  status: YouTubeConnectionStatus
   presets: StreamPreset | null
 }
 

--- a/packages/utils/src/blob-fetch.ts
+++ b/packages/utils/src/blob-fetch.ts
@@ -1,0 +1,48 @@
+// Client-side blob reachability for images destined to become YouTube stream
+// thumbnails. YouTube has no "set thumbnail by URL" API — we must hold the
+// bytes and POST them — and a browser `fetch()` of a cross-origin image is
+// CORS-blocked unless the host sends `Access-Control-Allow-Origin`. So an
+// image being viewable in an <img> tag does NOT mean we can re-upload it.
+// These helpers are the single source of truth for "can we actually get the
+// bytes". No server proxy — this stays fully client-side by design.
+
+// Plain-language copy for when an image can't be loaded as bytes. Deliberately
+// avoids "fetch"/"blob"/"CORS" — it's shown to non-technical users and is true
+// regardless of the underlying cause (CORS, 404, offline, timeout).
+export const UNFETCHABLE_THUMBNAIL_MESSAGE =
+  "We couldn't load an image from this link, so it can't be used as a thumbnail. Try a different link, or upload the image file directly."
+
+// Proves an arbitrary URL's bytes are reachable WITHOUT downloading the whole
+// resource: start the fetch, read only the first chunk off the response body
+// stream, then abort. CORS rejects the fetch before any chunk arrives, so a
+// successful first read means both "CORS passed" and "bytes are real" — at
+// bounded cost even for a multi-GB file. Resolves false on any failure; never
+// throws (used as a non-blocking gate at media-add time).
+export async function probeUrlFetchable(url: string): Promise<boolean> {
+  const controller = new AbortController()
+  try {
+    const res = await fetch(url, { signal: controller.signal })
+    if (!res.ok || !res.body) {
+      controller.abort()
+      return false
+    }
+    const reader = res.body.getReader()
+    await reader.read() // first chunk (or {done:true} for an empty 200) — both prove reachability
+    controller.abort()
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Fully resolves an image URL to its bytes. Thumbnails are images (small), so
+// reading the whole blob is fine here — unlike the probe above which guards
+// against arbitrary large media. Throws on any failure so the caller can
+// surface UNFETCHABLE_THUMBNAIL_MESSAGE and block.
+export async function fetchImageBlob(url: string): Promise<Blob> {
+  const res = await fetch(url)
+  if (!res.ok) {
+    throw new Error(`Image URL responded ${res.status}`)
+  }
+  return res.blob()
+}


### PR DESCRIPTION
All changes since the last PR to main (#54). Six commits across broadcast and notifications.

## Broadcast — YouTube connection health
- Google exposes no refresh-token expiry, so a dead refresh token is only detectable on a failed refresh. Added `youtube_connections.status` (`active` | `reauth_required`) — patch `2026-05-18-youtube-connection-status.sql` + folded into phase-01.
- Refresh endpoint now returns a distinct `reauth_required` (401) on `invalid_grant` vs transient `502`. Client persists the flag, clears it on reconnect.
- UI: reconnect banner + Sync/Create/Update/Delete disabled while unhealthy; Settings shows a "Reconnect required" state.

## Broadcast — safe delete ordering
- `deleteStream` now deletes the YouTube broadcast **first**, and the Supabase row only if that succeeds (404 = already gone counts as success). A failed external delete keeps the local row instead of the old delete-then-rollback dance. Now consistent with `deleteZoomMeeting`. Removed the dead `restoreLocalStream` helper.

## Broadcast — stream thumbnail CORS fix
- Resolve stream thumbnails to bytes client-side, killing the silent CORS failure (adds `blob_fetchable` probe + patch).

## Notifications
- Message template catalog: editable templates, token catalog + DB enrichment, Settings UI, tests (patch `2026-05-17-notification-message-templates.sql`).
- Enable Telegram link previews for action links (URL stays hidden inside the `<a>` tag).

## Verification
- `tsc -b` clean, `eslint` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)