### PR TITLE
fix(bookings): booking-level collection — resolve booking_items.collected_at 400

### DIFF
--- a/apps/console/package.json
+++ b/apps/console/package.json
@@ -20,6 +20,7 @@
     "@moc/utils": "*",
     "@supabase/supabase-js": "^2.101.1",
     "lucide-react": "^1.14.0",
+    "qrcode.react": "^4.2.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
     "react-router-dom": "^7.13.2",

--- a/apps/console/src/data/booking-row.ts
+++ b/apps/console/src/data/booking-row.ts
@@ -14,7 +14,6 @@ export const BOOKING_SELECT = `
   items:booking_items(
     id,
     equipment_id,
-    collected_at,
     equipment:equipment_id(id, name, category, thumbnail_url)
   )
 `;
@@ -22,7 +21,6 @@ export const BOOKING_SELECT = `
 export type BookingItemRow = {
   id: string;
   equipment_id: string;
-  collected_at: string | null;
   equipment:
     | {
         id: string;
@@ -69,7 +67,6 @@ function mapBookingItem(item: BookingItemRow): BookingItem {
     equipmentName: item.equipment?.name ?? "Unknown equipment",
     equipmentCategory: item.equipment?.category ?? ("other" as BookingItem["equipmentCategory"]),
     equipmentThumbnail: item.equipment?.thumbnail_url ?? null,
-    collectedAt: item.collected_at,
   };
 }
 

--- a/apps/console/src/data/mutate-booking.ts
+++ b/apps/console/src/data/mutate-booking.ts
@@ -6,7 +6,7 @@ import { BOOKING_SELECT, type BookingRow, mapBookingRow } from "./booking-row";
 // requester via MOC Request; the console can amend lifecycle/dates/notes but
 // not relabel the submission.
 export async function updateBooking(booking: Booking): Promise<Booking> {
-  const { error: bookingError } = await supabase
+  const { data, error } = await supabase
     .from("bookings")
     .update({
       booked_by: booking.bookedBy,
@@ -16,30 +16,8 @@ export async function updateBooking(booking: Booking): Promise<Booking> {
       notes: booking.notes || null,
       status: booking.status,
     })
-    .eq("id", booking.id);
-
-  if (bookingError) {
-    throw new Error(bookingError.message);
-  }
-
-  const itemResults = await Promise.all(
-    booking.items.map((item) =>
-      supabase
-        .from("booking_items")
-        .update({ collected_at: item.collectedAt })
-        .eq("id", item.id),
-    ),
-  );
-  const itemError = itemResults.find((result) => result.error)?.error;
-
-  if (itemError) {
-    throw new Error(itemError.message);
-  }
-
-  const { data, error } = await supabase
-    .from("bookings")
-    .select(BOOKING_SELECT)
     .eq("id", booking.id)
+    .select(BOOKING_SELECT)
     .single();
 
   if (error) {

--- a/apps/console/src/features/equipment/booking-drawer.tsx
+++ b/apps/console/src/features/equipment/booking-drawer.tsx
@@ -94,9 +94,9 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
     navigate(`/equipment/bookings/${booking.id}`);
   }
 
-  const persistBooking = useCallback(async (nextBooking?: Booking) => {
+  const persistBooking = useCallback(async () => {
     try {
-      await store.actions.save(nextBooking);
+      await store.actions.save();
       // A booking can hold multiple items, so a per-equipment-id sync
       // can't refresh them all in one call. Refetch the whole inventory.
       await refreshEquipment();
@@ -108,8 +108,6 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
 
   const collection = useBookingCollection({
     booking: store.state.draft,
-    onDraftChange: store.actions.replaceDraft,
-    onCollectionComplete: persistBooking,
     onItemCollected: (item) => {
       toast({ title: "Item collected", description: item.equipmentName, variant: "success" });
     },
@@ -164,7 +162,14 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
   }, [booking.id, closeDrawer, refreshEquipment, removeBooking, toast]);
 
   function handleSelectStatus(status: BookingStatus) {
+    const previousStatus = store.state.draft.status;
     store.actions.updateField("status", status);
+    // Setting the booking to checked_out is the act of collection, so stamp the
+    // actual handover moment onto checked_out_at — mirrors how returned fills
+    // returnedDate. Guarded on the transition so re-saving doesn't move it.
+    if (status === "checked_out" && previousStatus !== "checked_out") {
+      store.actions.updateField("checkedOutDate", new Date().toISOString());
+    }
     if (status === "returned" && !store.state.draft.returnedDate) {
       store.actions.updateField("returnedDate", new Date().toISOString());
     }
@@ -218,7 +223,7 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
         <div className="flex-1" />
         <Button.Icon
           variant="secondary"
-          aria-label={collection.state.isComplete ? "All items collected" : "Scan booking items"}
+          aria-label={collection.state.isComplete ? "All items scanned" : "Scan booking items"}
           disabled={!collection.state.canScan}
           icon={<ScanLine />}
           onClick={collection.actions.openScanner}
@@ -307,7 +312,7 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
         </div>
 
         {/* Items */}
-        <BookingItemsSection items={draft.items} onNavigate={closeDrawer} />
+        <BookingItemsSection items={draft.items} scannedItemIds={collection.state.scannedItemIds} onNavigate={closeDrawer} />
       </Drawer.Content>
 
       {store.state.isDirty && (
@@ -333,7 +338,7 @@ function BookingDrawerContent({ booking, onBookingClose, isDirtyRef, requestClos
         isStarting={collection.state.isStarting}
         isSupported={collection.state.isSupported}
         error={collection.state.error}
-        collectedCount={collection.state.collectedCount}
+        scannedCount={collection.state.scannedCount}
         totalCount={collection.state.totalCount}
         onClose={collection.actions.closeScanner}
         videoRef={collection.meta.videoRef}

--- a/apps/console/src/features/equipment/booking-items-section.tsx
+++ b/apps/console/src/features/equipment/booking-items-section.tsx
@@ -2,13 +2,22 @@ import { Badge } from "@moc/ui/components/display/badge";
 import { Label, Paragraph } from "@moc/ui/components/display/text";
 import { equipmentCategoryLabel } from "@moc/types/equipment";
 import type { BookingItem } from "@moc/types/equipment";
-import { formatUtcIsoInBrowserTimeZone } from "@moc/utils/browser-date-time";
 import { ChevronRight, Package } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 // Shared between the booking drawer and the booking detail page so the
-// equipment-item list renders identically in both places.
-export function BookingItemsSection({ items, onNavigate }: { items: BookingItem[]; onNavigate?: () => void }) {
+// equipment-item list renders identically in both places. `scannedItemIds`
+// reflects transient, per-session scan progress and is only supplied where a
+// scan flow is active; the "Scanned" tick is not persisted state.
+export function BookingItemsSection({
+  items,
+  scannedItemIds,
+  onNavigate,
+}: {
+  items: BookingItem[];
+  scannedItemIds?: ReadonlySet<string>;
+  onNavigate?: () => void;
+}) {
   return (
     <section className="mt-6 px-4">
       <Label.xs className="uppercase tracking-wide text-quaternary">
@@ -21,22 +30,20 @@ export function BookingItemsSection({ items, onNavigate }: { items: BookingItem[
           </Paragraph.sm>
         )}
         {items.map((item) => (
-          <BookingItemRow key={item.id} item={item} onNavigate={onNavigate} />
+          <BookingItemRow
+            key={item.id}
+            item={item}
+            isScanned={scannedItemIds?.has(item.id) ?? false}
+            onNavigate={onNavigate}
+          />
         ))}
       </div>
     </section>
   );
 }
 
-function BookingItemRow({ item, onNavigate }: { item: BookingItem; onNavigate?: () => void }) {
+function BookingItemRow({ item, isScanned, onNavigate }: { item: BookingItem; isScanned: boolean; onNavigate?: () => void }) {
   const navigate = useNavigate();
-  const collectedLabel = item.collectedAt
-    ? formatUtcIsoInBrowserTimeZone(item.collectedAt, {
-      dateStyle: "medium",
-      timeStyle: "short",
-      fallback: "Collected",
-    })
-    : null;
 
   function handleClick() {
     onNavigate?.();
@@ -61,13 +68,8 @@ function BookingItemRow({ item, onNavigate }: { item: BookingItem; onNavigate?: 
         <Paragraph.xs className="text-tertiary">
           {equipmentCategoryLabel[item.equipmentCategory]}
         </Paragraph.xs>
-        {collectedLabel ? (
-          <Paragraph.xs className="mt-0.5 text-tertiary">
-            Collected {collectedLabel}
-          </Paragraph.xs>
-        ) : null}
       </div>
-      {item.collectedAt ? <Badge color="green" label="Collected" /> : null}
+      {isScanned ? <Badge color="green" label="Scanned" /> : null}
       <ChevronRight className="size-4 text-quaternary" />
     </button>
   );

--- a/apps/console/src/features/equipment/booking-scan-helpers.ts
+++ b/apps/console/src/features/equipment/booking-scan-helpers.ts
@@ -1,9 +1,17 @@
-import type { Booking, BookingItem } from "@moc/types/equipment";
+import type { BookingItem } from "@moc/types/equipment";
+import { parseEquipmentQrPayload } from "./equipment-qr";
 
 function normalizeScannedValue(rawValue: string) {
   const trimmedValue = rawValue.trim();
   if (!trimmedValue) {
     return "";
+  }
+
+  // Structured equipment QR (JSON) — the canonical format produced by the
+  // per-equipment generator. Resolve straight to its equipment id.
+  const payload = parseEquipmentQrPayload(trimmedValue);
+  if (payload) {
+    return payload.id;
   }
 
   try {
@@ -16,14 +24,6 @@ function normalizeScannedValue(rawValue: string) {
   }
 }
 
-export function countCollectedBookingItems(items: BookingItem[]) {
-  return items.filter((item) => item.collectedAt).length;
-}
-
-export function areAllBookingItemsCollected(items: BookingItem[]) {
-  return items.length > 0 && countCollectedBookingItems(items) === items.length;
-}
-
 export function findBookingItemFromScan(items: BookingItem[], rawValue: string) {
   const normalizedValue = normalizeScannedValue(rawValue);
   if (!normalizedValue) {
@@ -33,21 +33,9 @@ export function findBookingItemFromScan(items: BookingItem[], rawValue: string) 
   return items.find((item) => item.equipmentId === normalizedValue || item.id === normalizedValue) ?? null;
 }
 
-export function buildCollectedBookingDraft(booking: Booking, itemId: string, collectedAt: string) {
-  const nextItems = booking.items.map((item) => {
-    if (item.id !== itemId || item.collectedAt) {
-      return item;
-    }
-
-    return {
-      ...item,
-      collectedAt,
-    };
-  });
-
-  return {
-    ...booking,
-    items: nextItems,
-    status: areAllBookingItemsCollected(nextItems) && booking.status === "booked" ? "checked_out" : booking.status,
-  };
+// Scan progress is transient (a Set of item ids in component state); collection
+// itself is a booking-level concern. "All scanned" just means every item in the
+// booking has been ticked off this session.
+export function areAllItemsScanned(items: BookingItem[], scannedItemIds: ReadonlySet<string>) {
+  return items.length > 0 && items.every((item) => scannedItemIds.has(item.id));
 }

--- a/apps/console/src/features/equipment/booking-scan-modal.tsx
+++ b/apps/console/src/features/equipment/booking-scan-modal.tsx
@@ -10,7 +10,7 @@ type BookingScanModalProps = {
   isStarting: boolean;
   isSupported: boolean;
   error: string | null;
-  collectedCount: number;
+  scannedCount: number;
   totalCount: number;
   onClose: () => void;
   videoRef: RefObject<HTMLVideoElement | null>;
@@ -21,7 +21,7 @@ export function BookingScanModal({
   isStarting,
   isSupported,
   error,
-  collectedCount,
+  scannedCount,
   totalCount,
   onClose,
   videoRef,
@@ -42,14 +42,14 @@ export function BookingScanModal({
               <div>
                 <Title.h6>Scan Booking Items</Title.h6>
                 <Paragraph.sm className="mt-1 text-tertiary">
-                  Scan each equipment QR code to mark it as collected.
+                  Scan each item to tick it off as you gather it.
                 </Paragraph.sm>
               </div>
             </Modal.Header>
 
             <Modal.Content className="flex-col gap-4 p-4">
               <div className="rounded-lg border border-secondary bg-secondary/40 p-3">
-                <Label.sm>{collectedCount} of {totalCount} collected</Label.sm>
+                <Label.sm>{scannedCount} of {totalCount} scanned</Label.sm>
               </div>
 
               {isSupported ? (

--- a/apps/console/src/features/equipment/equipment-qr-section.tsx
+++ b/apps/console/src/features/equipment/equipment-qr-section.tsx
@@ -1,0 +1,90 @@
+import { Button } from "@moc/ui/components/controls/button";
+import { Label, Paragraph } from "@moc/ui/components/display/text";
+import { QRCodeCanvas } from "qrcode.react";
+import { Download, Printer } from "lucide-react";
+import { useRef } from "react";
+import type { Equipment } from "@moc/types/equipment";
+import { buildEquipmentQrPayload } from "./equipment-qr";
+
+function toFileSlug(value: string) {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "equipment";
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Generates the printable identity QR for a single equipment item. The encoded
+// value is the structured payload from equipment-qr.ts, which the booking
+// scanner knows how to read.
+export function EquipmentQrSection({ equipment }: { equipment: Equipment }) {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const payload = buildEquipmentQrPayload(equipment);
+
+  function handleDownload() {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const link = document.createElement("a");
+    link.href = canvas.toDataURL("image/png");
+    link.download = `${toFileSlug(equipment.name)}-${toFileSlug(equipment.serialNumber)}-qr.png`;
+    link.click();
+  }
+
+  function handlePrint() {
+    const canvas = canvasRef.current;
+    if (!canvas) {
+      return;
+    }
+    const dataUrl = canvas.toDataURL("image/png");
+    const printWindow = window.open("", "_blank", "width=420,height=560");
+    if (!printWindow) {
+      return;
+    }
+    const name = escapeHtml(equipment.name);
+    const serial = escapeHtml(equipment.serialNumber);
+    printWindow.document.write(
+      `<!doctype html><html><head><title>${name}</title>` +
+        "<style>" +
+        "body{margin:0;display:flex;flex-direction:column;align-items:center;justify-content:center;" +
+        "min-height:100vh;font-family:system-ui,-apple-system,sans-serif;}" +
+        "img{width:280px;height:280px;}" +
+        "h1{font-size:18px;margin:16px 0 4px;text-align:center;}" +
+        "p{margin:0;color:#555;font-size:14px;}" +
+        "</style></head>" +
+        `<body><img src="${dataUrl}" alt="${name} QR code"/><h1>${name}</h1><p>${serial}</p>` +
+        "<script>window.onload=function(){window.focus();window.print();window.close();};</script>" +
+        "</body></html>",
+    );
+    printWindow.document.close();
+  }
+
+  return (
+    <section className="px-4">
+      <Label.xs className="uppercase tracking-wide text-quaternary">QR Code</Label.xs>
+      <div className="mt-3 flex flex-wrap items-center gap-4">
+        <div className="rounded-lg border border-secondary bg-white p-3">
+          <QRCodeCanvas ref={canvasRef} value={payload} size={160} level="M" marginSize={4} />
+        </div>
+        <div className="flex flex-col gap-3">
+          <Paragraph.sm className="text-tertiary">
+            Print and attach to the item. Scanning it during booking collection ticks it off automatically.
+          </Paragraph.sm>
+          <div className="flex gap-2">
+            <Button variant="secondary" icon={<Download />} onClick={handleDownload}>
+              Download
+            </Button>
+            <Button variant="secondary" icon={<Printer />} onClick={handlePrint}>
+              Print
+            </Button>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/console/src/features/equipment/equipment-qr.ts
+++ b/apps/console/src/features/equipment/equipment-qr.ts
@@ -1,0 +1,52 @@
+import type { Equipment } from "@moc/types/equipment";
+
+// Canonical shape encoded into an equipment QR code. Kept here as the single
+// source of truth so the generator and the booking scanner can't drift.
+export type EquipmentQrPayload = {
+  id: string;
+  name: string;
+  serialNumber: string;
+  url: string;
+};
+
+// Console deep link for the item. APP_BASE_URL is not exposed to the browser by
+// Vite, so we build from the current origin like the rest of the app does.
+export function buildEquipmentQrUrl(id: string): string {
+  return `${window.location.origin}/equipment/${id}`;
+}
+
+export function buildEquipmentQrPayload(
+  equipment: Pick<Equipment, "id" | "name" | "serialNumber">,
+): string {
+  const payload: EquipmentQrPayload = {
+    id: equipment.id,
+    name: equipment.name,
+    serialNumber: equipment.serialNumber,
+    url: buildEquipmentQrUrl(equipment.id),
+  };
+  return JSON.stringify(payload);
+}
+
+// Parses a scanned value as the structured equipment payload. Returns null for
+// anything that isn't a JSON object carrying a non-empty string id, so callers
+// can fall back to URL / bare-id handling.
+export function parseEquipmentQrPayload(rawValue: string): EquipmentQrPayload | null {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(rawValue);
+  } catch {
+    return null;
+  }
+
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    "id" in parsed &&
+    typeof (parsed as { id: unknown }).id === "string" &&
+    (parsed as { id: string }).id.length > 0
+  ) {
+    return parsed as EquipmentQrPayload;
+  }
+
+  return null;
+}

--- a/apps/console/src/features/equipment/use-booking-collection.ts
+++ b/apps/console/src/features/equipment/use-booking-collection.ts
@@ -1,17 +1,10 @@
 import type { Booking, BookingItem } from "@moc/types/equipment";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useQrScanner } from "@/hooks/use-qr-scanner";
-import {
-  areAllBookingItemsCollected,
-  buildCollectedBookingDraft,
-  countCollectedBookingItems,
-  findBookingItemFromScan,
-} from "./booking-scan-helpers";
+import { areAllItemsScanned, findBookingItemFromScan } from "./booking-scan-helpers";
 
 type UseBookingCollectionOptions = {
   booking: Booking;
-  onDraftChange: (booking: Booking) => void;
-  onCollectionComplete: (booking: Booking) => Promise<void>;
   onItemCollected: (item: BookingItem) => void;
   onItemAlreadyCollected: (item: BookingItem) => void;
   onUnknownCode: (rawValue: string) => void;
@@ -19,20 +12,32 @@ type UseBookingCollectionOptions = {
 
 export function useBookingCollection({
   booking,
-  onDraftChange,
-  onCollectionComplete,
   onItemCollected,
   onItemAlreadyCollected,
   onUnknownCode,
 }: UseBookingCollectionOptions) {
+  // Per-session scan progress only — never persisted. The booking is marked
+  // collected explicitly via its status (see handleSelectStatus in the screens),
+  // not by scanning. These ticks just help confirm every item was gathered.
+  const [scannedItemIds, setScannedItemIds] = useState<ReadonlySet<string>>(() => new Set());
   const bookingRef = useRef(booking);
+  const scannedItemIdsRef = useRef(scannedItemIds);
   const closeScannerRef = useRef<() => void>(() => undefined);
 
   useEffect(() => {
     bookingRef.current = booking;
   }, [booking]);
 
-  const handleDetected = useCallback(async (rawValue: string) => {
+  useEffect(() => {
+    scannedItemIdsRef.current = scannedItemIds;
+  }, [scannedItemIds]);
+
+  // Drop scan progress when the hook is pointed at a different booking.
+  useEffect(() => {
+    setScannedItemIds(new Set());
+  }, [booking.id]);
+
+  const handleDetected = useCallback((rawValue: string) => {
     const currentBooking = bookingRef.current;
     const matchedItem = findBookingItemFromScan(currentBooking.items, rawValue);
 
@@ -41,27 +46,21 @@ export function useBookingCollection({
       return;
     }
 
-    if (matchedItem.collectedAt) {
+    if (scannedItemIdsRef.current.has(matchedItem.id)) {
       onItemAlreadyCollected(matchedItem);
       return;
     }
 
-    const collectedAt = new Date().toISOString();
-    const nextBooking = buildCollectedBookingDraft(currentBooking, matchedItem.id, collectedAt);
-    const updatedItem = nextBooking.items.find((item) => item.id === matchedItem.id);
+    const nextScanned = new Set(scannedItemIdsRef.current);
+    nextScanned.add(matchedItem.id);
+    scannedItemIdsRef.current = nextScanned;
+    setScannedItemIds(nextScanned);
+    onItemCollected(matchedItem);
 
-    bookingRef.current = nextBooking;
-    onDraftChange(nextBooking);
-
-    if (updatedItem) {
-      onItemCollected(updatedItem);
-    }
-
-    if (areAllBookingItemsCollected(nextBooking.items)) {
+    if (areAllItemsScanned(currentBooking.items, nextScanned)) {
       closeScannerRef.current();
-      await onCollectionComplete(nextBooking);
     }
-  }, [onCollectionComplete, onDraftChange, onItemAlreadyCollected, onItemCollected, onUnknownCode]);
+  }, [onItemAlreadyCollected, onItemCollected, onUnknownCode]);
 
   const scanner = useQrScanner({ onDetected: handleDetected });
   const closeScanner = scanner.actions.closeScanner;
@@ -73,9 +72,12 @@ export function useBookingCollection({
     closeScannerRef.current = closeScanner;
   }, [closeScanner]);
 
-  const collectedCount = useMemo(() => countCollectedBookingItems(booking.items), [booking.items]);
+  const scannedCount = useMemo(
+    () => booking.items.filter((item) => scannedItemIds.has(item.id)).length,
+    [booking.items, scannedItemIds],
+  );
   const totalCount = booking.items.length;
-  const isComplete = useMemo(() => areAllBookingItemsCollected(booking.items), [booking.items]);
+  const isComplete = useMemo(() => areAllItemsScanned(booking.items, scannedItemIds), [booking.items, scannedItemIds]);
   const canScan = totalCount > 0 && !isComplete;
 
   const openScanner = useCallback(() => {
@@ -88,9 +90,10 @@ export function useBookingCollection({
   return {
     state: {
       canScan,
-      collectedCount,
+      scannedCount,
       isComplete,
       totalCount,
+      scannedItemIds,
       ...scannerState,
     },
     actions: {

--- a/apps/console/src/features/equipment/use-booking-store.ts
+++ b/apps/console/src/features/equipment/use-booking-store.ts
@@ -14,7 +14,6 @@ type BookingStoreState = {
 
 type Action =
   | { type: "UPDATE_FIELD"; field: keyof Booking; value: Booking[keyof Booking] }
-  | { type: "REPLACE_DRAFT"; booking: Booking }
   | { type: "SAVE_START" }
   | { type: "SAVE_SUCCESS"; booking: Booking }
   | { type: "SAVE_ERROR"; error: string }
@@ -25,8 +24,6 @@ function reducer(state: BookingStoreState, action: Action): BookingStoreState {
   switch (action.type) {
     case "UPDATE_FIELD":
       return { ...state, draft: { ...state.draft, [action.field]: action.value } };
-    case "REPLACE_DRAFT":
-      return { ...state, draft: action.booking };
     case "SAVE_START":
       return { ...state, isSaving: true, error: null };
     case "SAVE_SUCCESS":
@@ -69,17 +66,10 @@ export function useBookingStore(initialBooking: Booking, options?: UseBookingSto
     dispatch({ type: "UPDATE_FIELD", field, value });
   }, []);
 
-  const replaceDraft = useCallback((booking: Booking) => {
-    dispatch({ type: "REPLACE_DRAFT", booking });
-  }, []);
-
-  const save = useCallback(async (draftOverride?: Booking) => {
+  const save = useCallback(async () => {
     const previous = state.original;
-    const next = draftOverride ?? state.draft;
+    const next = state.draft;
 
-    if (draftOverride) {
-      dispatch({ type: "REPLACE_DRAFT", booking: draftOverride });
-    }
     dispatch({ type: "SAVE_START" });
     options?.syncBooking?.(next);
 
@@ -114,7 +104,6 @@ export function useBookingStore(initialBooking: Booking, options?: UseBookingSto
     },
     actions: {
       updateField,
-      replaceDraft,
       save,
       discard,
       reset,

--- a/apps/console/src/screens/equipment/booking/detail/page.tsx
+++ b/apps/console/src/screens/equipment/booking/detail/page.tsx
@@ -96,9 +96,9 @@ function BookingDetailContent({ booking }: { booking: Booking }) {
     return () => window.removeEventListener("beforeunload", handleBeforeUnload);
   }, [store.state.isDirty]);
 
-  const persistBooking = useCallback(async (nextBooking?: Booking) => {
+  const persistBooking = useCallback(async () => {
     try {
-      await store.actions.save(nextBooking);
+      await store.actions.save();
       // A booking can hold multiple items, so refetch the whole inventory
       // to keep availability / bookedBy in sync across all of them.
       await refreshEquipment();
@@ -110,8 +110,6 @@ function BookingDetailContent({ booking }: { booking: Booking }) {
 
   const collection = useBookingCollection({
     booking: store.state.draft,
-    onDraftChange: store.actions.replaceDraft,
-    onCollectionComplete: persistBooking,
     onItemCollected: (item) => {
       toast({ title: "Item collected", description: item.equipmentName, variant: "success" });
     },
@@ -164,7 +162,14 @@ function BookingDetailContent({ booking }: { booking: Booking }) {
   }, [booking.id, navigate, refreshEquipment, removeBooking, toast]);
 
   function handleSelectStatus(status: BookingStatus) {
+    const previousStatus = store.state.draft.status;
     store.actions.updateField("status", status);
+    // Setting the booking to checked_out is the act of collection, so stamp the
+    // actual handover moment onto checked_out_at — mirrors how returned fills
+    // returnedDate. Guarded on the transition so re-saving doesn't move it.
+    if (status === "checked_out" && previousStatus !== "checked_out") {
+      store.actions.updateField("checkedOutDate", new Date().toISOString());
+    }
     if (status === "returned" && !store.state.draft.returnedDate) {
       store.actions.updateField("returnedDate", new Date().toISOString());
     }
@@ -199,7 +204,7 @@ function BookingDetailContent({ booking }: { booking: Booking }) {
     <section className="mx-auto max-w-content-md">
       <TopBarActions>
         <Button variant="secondary" icon={<ScanLine />} onClick={collection.actions.openScanner} disabled={!collection.state.canScan}>
-          {collection.state.isComplete ? "All collected" : "Scan"}
+          {collection.state.isComplete ? "All scanned" : "Scan"}
         </Button>
         {store.state.isDirty ? (
           <>
@@ -268,7 +273,7 @@ function BookingDetailContent({ booking }: { booking: Booking }) {
 
       {/* Items */}
       <Divider className="px-4 my-2" />
-      <BookingItemsSection items={draft.items} />
+      <BookingItemsSection items={draft.items} scannedItemIds={collection.state.scannedItemIds} />
 
       {/* Navigation guard modal */}
       <UnsavedChangesModal
@@ -286,7 +291,7 @@ function BookingDetailContent({ booking }: { booking: Booking }) {
         isStarting={collection.state.isStarting}
         isSupported={collection.state.isSupported}
         error={collection.state.error}
-        collectedCount={collection.state.collectedCount}
+        scannedCount={collection.state.scannedCount}
         totalCount={collection.state.totalCount}
         onClose={collection.actions.closeScanner}
         videoRef={collection.meta.videoRef}

--- a/apps/console/src/screens/equipment/detail/page.tsx
+++ b/apps/console/src/screens/equipment/detail/page.tsx
@@ -10,6 +10,7 @@ import { DeleteEquipmentModal } from "@/features/equipment/delete-equipment-moda
 import { EquipmentPropertiesSection } from "@/features/equipment/equipment-properties-section";
 import { EquipmentNotesSection } from "@/features/equipment/equipment-notes-section";
 import { BookingHistorySection } from "@/features/equipment/booking-history-section";
+import { EquipmentQrSection } from "@/features/equipment/equipment-qr-section";
 import { useEquipmentStore } from "@/features/equipment/use-equipment-store";
 import { useEquipment } from "@/features/equipment/equipment-provider";
 import { useFeedback } from "@moc/ui/components/feedback/feedback-provider";
@@ -233,6 +234,12 @@ function EquipmentDetailContent({ equipment }: { equipment: Equipment }) {
           bookings={bookings}
           isLoading={isLoadingBookings}
         />
+      </div>
+
+      {/* QR Code */}
+      <Divider className="px-4 my-2" />
+      <div className="py-4">
+        <EquipmentQrSection equipment={draft} />
       </div>
 
       {/* Navigation guard modal */}

--- a/bun.lock
+++ b/bun.lock
@@ -56,6 +56,7 @@
         "@moc/utils": "*",
         "@supabase/supabase-js": "^2.101.1",
         "lucide-react": "^1.14.0",
+        "qrcode.react": "^4.2.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
         "react-router-dom": "^7.13.2",
@@ -987,6 +988,8 @@
     "pretty-bytes": ["pretty-bytes@6.1.1", "", {}, "sha512-mQUvGU6aUFQ+rNvTIAcZuWGRT9a6f6Yrg9bHs4ImKF+HZCEK+plBvnAZYSIQztknZF2qnzNtr6F8s0+IuptdlQ=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "qrcode.react": ["qrcode.react@4.2.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-QpgqWi8rD9DsS9EP3z7BT+5lY5SFhsqGjpgW5DY/i3mK4M9DTBNz3ErMi8BWYEfI3L0d8GIbGmcdFAS1uIRGjA=="],
 
     "randombytes": ["randombytes@2.1.0", "", { "dependencies": { "safe-buffer": "^5.1.0" } }, "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ=="],
 

--- a/docs/phases/patches/2026-05-31-booking-item-collected-at.sql
+++ b/docs/phases/patches/2026-05-31-booking-item-collected-at.sql
@@ -1,3 +1,0 @@
--- Track per-item collection timestamps captured during QR scanning.
-ALTER TABLE public.booking_items
-  ADD COLUMN IF NOT EXISTS collected_at timestamptz NULL;

--- a/docs/phases/phase-01-schema.sql
+++ b/docs/phases/phase-01-schema.sql
@@ -230,7 +230,6 @@ CREATE TABLE IF NOT EXISTS public.booking_items (
   id           uuid PRIMARY KEY DEFAULT gen_random_uuid(),
   booking_id   uuid NOT NULL REFERENCES public.bookings(id)  ON DELETE CASCADE,
   equipment_id uuid NOT NULL REFERENCES public.equipment(id) ON DELETE CASCADE,
-  collected_at timestamptz NULL,
   UNIQUE (booking_id, equipment_id)
 );
 

--- a/docs/superpowers/specs/2026-06-01-booking-collection-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-01-booking-collection-redesign-design.md
@@ -1,0 +1,104 @@
+# Booking collection redesign — booking-level collection, transient scan ticks
+
+**Date:** 2026-06-01
+**Status:** Approved
+**Branch:** `fix/booking-collection-redesign`
+
+## Background
+
+Commit `22acb12` ("feat(bookings): add QR collection flow") introduced per-item
+collection: scanning a QR stamped `booking_items.collected_at`, and the shared
+`BOOKING_SELECT` query was changed to read that column. The column was only ever
+added via a manual SQL patch (`docs/phases/patches/2026-05-31-booking-item-collected-at.sql`)
+that was never applied to the live database. Because `BOOKING_SELECT` is shared
+by every booking read, the missing column made all booking queries fail with
+`42703 column booking_items.collected_at does not exist`, so **no bookings were
+visible in the console at all.**
+
+This redesign removes per-item collection entirely and moves the notion of
+"collected" up to the booking level, which also makes that bug disappear with no
+database migration.
+
+## Goals
+
+1. Scanning a QR **ticks items in local React state only** — transient,
+   per-session, never persisted, not part of the `Booking`/`BookingItem` type.
+2. "Collected" is a **booking-level** concept carried by `status` +
+   `checked_out_at`. There is no per-item collected state.
+3. Remove `booking_items.collected_at` (column, type field, all reads/writes).
+
+## Decisions (from brainstorming)
+
+- **Where the collected timestamp lives:** reuse the existing
+  `bookings.checked_out_at` (no new column). It is `NOT NULL` and already
+  populated at creation, so "collected vs not" is carried by `status`.
+- **What Save does:** when `status` transitions to `checked_out`, stamp
+  `checked_out_at = now()` (the actual handover moment), mirroring how selecting
+  `returned` already auto-fills `returnedDate`.
+- **What marks a booking collected:** the **status dropdown** drives it.
+  Scanning is purely a visual checklist and is fully decoupled from the commit.
+  Whenever status becomes `checked_out` and the booking is saved,
+  `checked_out_at` is stamped.
+- **Tick-state storage:** a `Set<string>` of scanned item IDs owned by
+  `useBookingCollection`, decoupled from the `Booking` type.
+
+## Behavior
+
+| Area | Before | After |
+|---|---|---|
+| Scan a QR | Sets `item.collectedAt`, mutates the draft booking | Adds item id to a local `Set`; shows a transient "Scanned" tick |
+| All items scanned | Auto-closes scanner **and auto-saves** | Auto-closes scanner; **no save, no status change** |
+| Marking collected | Implicit, per-item | Explicit: status → `checked_out` via dropdown, then Save |
+| `checked_out_at` | Untouched by scanning | Stamped to `now` on the `→ checked_out` transition |
+| Item display | Green "Collected" badge + per-item timestamp | Transient "Scanned" tick during a scan session only |
+
+## Components / files
+
+**Types + data layer (this alone restores booking visibility):**
+- `packages/types/src/equipment/booking.ts` — drop `collectedAt` from `BookingItem`.
+- `apps/console/src/data/booking-row.ts` — drop `collected_at` from `BOOKING_SELECT`,
+  `BookingItemRow`, and `mapBookingItem`.
+- `apps/console/src/data/mutate-booking.ts` — remove the per-item `collected_at`
+  write loop; `updateBooking` updates only the booking header then re-selects.
+
+**Scan flow:**
+- `apps/console/src/features/equipment/booking-scan-helpers.ts` — keep
+  `normalizeScannedValue` + `findBookingItemFromScan`; replace the
+  `collectedAt`-based helpers with `areAllItemsScanned(items, scannedIds)`;
+  remove `buildCollectedBookingDraft`.
+- `apps/console/src/features/equipment/use-booking-collection.ts` — own a
+  `Set<string>` of scanned IDs (reset when `booking.id` changes); drop
+  `onDraftChange`/`onCollectionComplete`; expose `scannedItemIds`.
+- `apps/console/src/features/equipment/booking-items-section.tsx` — remove the
+  per-item collected badge/timestamp; add an optional `scannedItemIds` prop that
+  renders a transient "Scanned" tick.
+- `apps/console/src/features/equipment/booking-scan-modal.tsx` — wording: the
+  counter reads "X of Y scanned".
+- `apps/console/src/features/equipment/use-booking-store.ts` — remove the
+  now-unused `REPLACE_DRAFT` action and the `save(draftOverride)` parameter.
+
+**Screens (both share the hook + section):**
+- `apps/console/src/screens/equipment/booking/detail/page.tsx`
+- `apps/console/src/features/equipment/booking-drawer.tsx`
+  - Rewire `useBookingCollection` (drop the removed callbacks).
+  - Pass `scannedItemIds` to `BookingItemsSection`.
+  - In `handleSelectStatus`, stamp `checkedOutDate = now` on the
+    `→ checked_out` transition.
+
+**Schema:**
+- `docs/phases/phase-01-schema.sql` — remove the `collected_at` column from
+  `booking_items`.
+- Delete `docs/phases/patches/2026-05-31-booking-item-collected-at.sql`.
+
+## Bug-fix note
+
+Removing `collected_at` from `BOOKING_SELECT` returns the booking query to its
+pre-`22acb12` shape, which the live database already supports. The original
+"can't see any bookings" failure is resolved with **no database change required.**
+
+## Out of scope
+
+- The `BarcodeDetector`-based camera scanning in `use-qr-scanner.ts` is unchanged
+  (still Chromium/Android only; unsupported browsers show the existing empty state).
+- `vite.config.ts` / `tsconfig.app.json` changes from `22acb12` are unrelated and
+  left as-is.

--- a/docs/superpowers/specs/2026-06-01-equipment-qr-generator-design.md
+++ b/docs/superpowers/specs/2026-06-01-equipment-qr-generator-design.md
@@ -1,0 +1,86 @@
+# Per-equipment QR generator + JSON-aware scanner
+
+**Date:** 2026-06-01
+**Status:** Approved
+**Branch:** `fix/booking-collection-redesign` (continues from the booking-collection redesign, whose scanner helpers this builds on)
+
+## Goal
+
+Generate a printable QR code for each equipment item. The QR encodes a
+structured JSON payload (name, serial number, id, url). The booking QR scanner
+parses that payload to identify the equipment, so a printed label stuck on the
+gear can be scanned during booking collection.
+
+## Payload format (single source of truth)
+
+A new module `apps/console/src/features/equipment/equipment-qr.ts` owns the
+encoding so the generator and scanner cannot drift:
+
+```ts
+type EquipmentQrPayload = { id: string; name: string; serialNumber: string; url: string };
+
+buildEquipmentQrPayload(equipment) → string          // JSON.stringify(payload)
+parseEquipmentQrPayload(rawValue)  → EquipmentQrPayload | null   // JSON.parse + shape guard
+```
+
+The QR encodes exactly the four requested fields:
+
+```json
+{ "id": "…", "name": "…", "serialNumber": "…", "url": "https://…/equipment/…" }
+```
+
+- `url` is the console deep link: `${window.location.origin}/equipment/${id}`.
+  (`APP_BASE_URL` is not exposed to the browser by Vite; the app already builds
+  client links from `window.location.origin`.)
+- `parseEquipmentQrPayload` returns the payload only when the parsed value is an
+  object with a non-empty string `id`; otherwise `null`.
+
+## QR section component — `equipment-qr-section.tsx`
+
+A new "QR Code" section on the equipment detail page, placed after Booking
+History behind a `<Divider>` (matching the Properties / Notes / History section
+pattern).
+
+- Renders `<QRCodeCanvas>` from `qrcode.react` with `value = buildEquipmentQrPayload(equipment)`,
+  on a white padded surface (contrast in dark mode), with a built-in quiet-zone
+  margin so the exported image scans reliably.
+- Shows the equipment **name + serial** as a human-readable caption.
+- **Download** — `canvas.toDataURL("image/png")` → downloads `<name>-<serial>.png`.
+- **Print** — opens a minimal print window containing only the QR image + caption
+  and calls `print()`, producing a clean physical label (not the whole page).
+- Reads from the page's `draft`, so name/serial reflect unsaved edits already on
+  screen.
+
+Mounted in `apps/console/src/screens/equipment/detail/page.tsx` as
+`<EquipmentQrSection equipment={draft} />`.
+
+## Scanner becomes JSON-aware
+
+Extend `normalizeScannedValue` in
+`apps/console/src/features/equipment/booking-scan-helpers.ts` to resolve a scan
+in this order:
+
+1. **JSON** — `parseEquipmentQrPayload(raw)`; if it returns a payload, use its
+   `id` (the new equipment QR).
+2. **URL** — existing `equipmentId` / `id` query param or last path segment.
+3. **Bare id** — existing last-segment fallback.
+
+`findBookingItemFromScan` already matches the resolved value against
+`item.equipmentId`, so scanning the new QR during booking collection ticks the
+correct item. Existing URL / bare-id QRs keep working.
+
+## Files
+
+- **New:** `equipment-qr.ts`, `equipment-qr-section.tsx`
+- **Edit:** `screens/equipment/detail/page.tsx` (mount the section),
+  `booking-scan-helpers.ts` (JSON-aware resolve)
+- **Dependency:** add `qrcode.react` to `apps/console` (ships its own types)
+
+## Out of scope
+
+- No database or `Equipment` type changes — the QR is derived from existing
+  fields.
+- Scoped to the equipment detail page. The section component is reusable if the
+  QR is later wanted elsewhere (e.g. an equipment drawer).
+- Camera/scanning hardware (`use-qr-scanner.ts`) is unchanged; only the value
+  interpretation (`normalizeScannedValue`) is extended.

--- a/packages/types/src/equipment/booking.ts
+++ b/packages/types/src/equipment/booking.ts
@@ -8,7 +8,6 @@ export type BookingItem = {
   equipmentName: string;
   equipmentCategory: EquipmentCategory;
   equipmentThumbnail: string | null;
-  collectedAt: string | null;
 };
 
 export type Booking = {


### PR DESCRIPTION
## What & why

Clicking a booking link (e.g. one sent to Telegram) opened the booking detail page stuck on a loading spinner, with a `400` and:

```
column booking_items_1.collected_at does not exist
```

### Root cause

Commit `22acb12` ("add QR collection flow") introduced **per-item** collection: scanning a QR stamped `booking_items.collected_at`, and the **shared** `BOOKING_SELECT` query was changed to read that column. The column was only ever added via a manual SQL patch (`2026-05-31-booking-item-collected-at.sql`) that **was never applied to the live database**. Because `BOOKING_SELECT` backs *every* booking read, the missing column made all booking queries fail with `42703 column booking_items.collected_at does not exist` — so booking pages never loaded.

### Fix

This branch redesigns collection to be **booking-level** rather than per-item, which also makes the bug disappear **with no database migration required**:

- "Collected" is now carried by the booking's `status` + existing `checked_out_at` (stamped on the `→ checked_out` transition), reusing columns the live DB already has.
- Scanning a QR is now a **transient, per-session checklist** (a local `Set<string>` of scanned item IDs in `useBookingCollection`) — never persisted, not part of the `Booking`/`BookingItem` type.
- `collected_at` is removed everywhere: `BOOKING_SELECT`, `BookingItemRow`/`mapBookingItem`, the `mutate-booking` write loop, the `BookingItem` type, `phase-01-schema.sql`, and the orphaned patch file is deleted.

Returning `BOOKING_SELECT` to its pre-`22acb12` shape matches what the live database already supports, so **no DB change is needed** — the deployed app just needs this build.

Also includes the per-equipment QR generator (`equipment-qr-section.tsx` / `equipment-qr.ts`) from the same redesign.

> Note: the production error originates from a **stale deployed bundle** that still queries `collected_at`. Merging + redeploying this build is what clears it.

## Spec

- `docs/superpowers/specs/2026-06-01-booking-collection-redesign-design.md`
- `docs/superpowers/specs/2026-06-01-equipment-qr-generator-design.md`

## Test plan

- [ ] Open a booking detail page via its link — loads (no 400, no spinner hang).
- [ ] Booking list and equipment screens render bookings again.
- [ ] Scan QRs in the collection modal — items tick "X of Y scanned"; ticks reset on a different booking and are not persisted.
- [ ] Set status → `checked_out` and Save — `checked_out_at` stamped to now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)