### PR TITLE
docs(agents): require explicit per-action permission for branches and pushes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,13 @@ This file is the non-negotiable source of truth for how AI agents create, modify
 - Follow existing patterns before introducing new ones.
 - Do not add new libraries without strong justification and explicit approval.
 
+## Git and version control (strict)
+
+- Never create a branch without explicit permission from the user for that specific action.
+- Never push to any remote without explicit permission from the user for that specific action.
+- Permission is per-action and does not carry over. Approval given earlier in a thread, conversation, or session does not authorize a later branch creation or push — ask again every time.
+- Committing locally, creating PRs, and other git operations still follow the user's instruction for the current task; when in doubt, ask before doing anything that changes branches or touches a remote.
+
 ## Before adding UI or logic
 
 You must do all of the following before creating any new component, hook, or utility:


### PR DESCRIPTION
## What & why

Adds a strict **"Git and version control"** section to `AGENTS.md` codifying a workflow rule:

- Never create a branch without explicit permission for that specific action.
- Never push to a remote without explicit permission for that specific action.
- **Permission is per-action and does not carry over** — approval given earlier in a thread/session does not authorize a later branch creation or push; ask again every time.
- Local commits and PR creation still follow the current task's instruction; when in doubt about anything that changes branches or touches a remote, ask first.

This makes the agent's git behavior predictable and keeps branch/remote operations under explicit human control.

## Scope

- One file changed: `AGENTS.md` (new section inserted after "Core principles").
- Branched off `main` so this PR contains **only** the rule change — independent of the in-flight booking-collection work in #56.

🤖 Generated with [Claude Code](https://claude.com/claude-code)